### PR TITLE
fix: datetime naive/aware + missing croniter dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
 dependencies = [
     "mcp>=1.0.0",
     "pyyaml>=6.0",
+    "croniter>=2.0.0",
 ]
 
 [project.urls]

--- a/src/task_orchestrator/engine.py
+++ b/src/task_orchestrator/engine.py
@@ -63,6 +63,14 @@ TRANSITIONS = {
 }
 
 
+def _parse_dt(s: str) -> datetime:
+    """Parse ISO datetime string, assuming UTC if no timezone info."""
+    dt = datetime.fromisoformat(s)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -655,7 +663,7 @@ def get_context(item_id: str | None = None, include_ancestors: bool = False) -> 
             "SELECT * FROM work_items WHERE status IN ('queue','work')"
         ).fetchall():
             item = _row_to_dict(row)
-            updated = datetime.fromisoformat(item["updated_at"])
+            updated = _parse_dt(item["updated_at"])
             days = (now_dt - updated).days
             if (item["status"] == "queue" and days > 7) or (item["status"] == "work" and days > 3):
                 item["stale_days"] = days
@@ -954,7 +962,7 @@ def get_metrics(days: int = 30) -> dict:
         ).fetchall()
         week_counts: dict[str, int] = {}
         for r in rows:
-            dt = datetime.fromisoformat(r["updated_at"])
+            dt = _parse_dt(r["updated_at"])
             iso = dt.isocalendar()
             key = f"{iso[0]}-W{iso[1]:02d}"
             week_counts[key] = week_counts.get(key, 0) + 1
@@ -967,7 +975,7 @@ def get_metrics(days: int = 30) -> dict:
         ).fetchall()
         if lt_rows:
             total_secs = sum(
-                (datetime.fromisoformat(r["updated_at"]) - datetime.fromisoformat(r["created_at"])).total_seconds()
+                (_parse_dt(r["updated_at"]) - _parse_dt(r["created_at"])).total_seconds()
                 for r in lt_rows
             )
             lead_time_avg = total_secs / len(lt_rows)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -595,3 +595,43 @@ def test_metrics_throughput():
         assert entry["week"].startswith(str(now.year))
         assert "-W" in entry["week"]
         assert isinstance(entry["count"], int)
+
+
+# --- _parse_dt helper ---
+
+def test_parse_dt_aware():
+    dt = engine._parse_dt("2026-05-03T12:00:00+00:00")
+    assert dt.tzinfo is not None
+
+def test_parse_dt_naive_assumes_utc():
+    dt = engine._parse_dt("2026-05-03 12:00:00")
+    assert dt.tzinfo == timezone.utc
+
+def test_get_context_with_naive_timestamps():
+    """get_context should not crash when items have naive datetime strings."""
+    item = _create("Naive TS item")
+    # Manually set created_at/updated_at to naive format (simulating old/imported data)
+    conn = db.get_connection()
+    conn.execute(
+        "UPDATE work_items SET created_at='2026-01-01 00:00:00', updated_at='2026-01-01 00:00:00' WHERE id=?",
+        (item["id"],),
+    )
+    conn.commit()
+    conn.close()
+    # Should not raise "can't subtract offset-naive and offset-aware datetimes"
+    ctx = engine.get_context()
+    assert "counts" in ctx
+
+def test_get_metrics_with_naive_timestamps():
+    """get_metrics should not crash when done items have naive datetime strings."""
+    item = _create("Naive metrics item")
+    engine.advance_item(item["id"], "complete")
+    conn = db.get_connection()
+    conn.execute(
+        "UPDATE work_items SET created_at='2026-01-01 00:00:00', updated_at='2026-05-03 00:00:00' WHERE id=?",
+        (item["id"],),
+    )
+    conn.commit()
+    conn.close()
+    metrics = engine.get_metrics(days=365)
+    assert metrics["lead_time_avg_seconds"] > 0


### PR DESCRIPTION
## Changes

- Fix mixed naive/aware datetime comparison in `get_context` and `get_metrics` (#22)
- Add `croniter` to `dependencies` in `pyproject.toml` — was imported in `engine.py` but undeclared, causing `ModuleNotFoundError` on clean installs via `uvx`

## Testing
- `get_context()` no longer raises `can't subtract offset-naive and offset-aware datetimes`
- `uvx task-orchestrator-py` starts without `ModuleNotFoundError: No module named 'croniter'`