### PR TITLE
feat: memory bridge + workspace guide (#27)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - uses: astral-sh/setup-uv@v7
       - name: Install
-        run: uv sync --group dev
+        run: uv sync --extra test
       - name: Test
         run: uv run pytest tests/ -v --tb=short

--- a/docs/WORKSPACE-GUIDE.md
+++ b/docs/WORKSPACE-GUIDE.md
@@ -1,0 +1,133 @@
+# Workspace Guide
+
+## Overview
+
+Workspaces group related items by tags, enabling scoped queries and context isolation. Each workspace maps to a set of item tags and optional metadata for richer context.
+
+## Configuration
+
+Workspaces are stored in `workspaces.json` (next to the DB file). Create via the `manage_workspaces` tool or edit the JSON directly.
+
+### Schema
+
+```json
+{
+  "workspace_name": {
+    "tags": ["tag1", "tag2"],
+    "memory_tags": ["mem-tag1", "mem-tag2"],
+    "repos": ["/path/to/repo"],
+    "conventions": "Free-text coding conventions",
+    "description": "Brief description of this workspace"
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `tags` | list[str] | yes | Item tags that belong to this workspace. Used to filter items in scoped queries. |
+| `memory_tags` | list[str] | no | Tags to search in external memory service (mcp-memory-service). |
+| `repos` | list[str] | no | Repository paths associated with this workspace. |
+| `conventions` | str | no | Coding conventions, style rules, or patterns for this workspace. |
+| `description` | str | no | Workspace brief — injected into context for subagents. |
+
+## The 2-Level Context Pattern
+
+Task orchestrator uses a 2-level documentation strategy:
+
+### Level 1 — Inline (always available)
+
+Lives in the orchestrator DB. Returned by `get_context`, `get_workspace_context`.
+
+- **Items**: tasks, their status, dependencies, hierarchy
+- **Notes**: per-phase documentation (queue/work/review)
+- **Workspace brief**: the `description` field — concise summary for subagents
+
+This is the "working memory" — always available, always current.
+
+### Level 2 — Reference (on-demand)
+
+Lives in **mcp-memory-service**. Accessed via `memory_tags`.
+
+- Architecture decisions, ADRs
+- Deep technical context (how systems work, why decisions were made)
+- Historical context (past bugs, lessons learned)
+- Domain knowledge (business rules, API specs)
+
+This is the "long-term memory" — rich context fetched when needed.
+
+### How It Works
+
+1. Agent calls `get_context(workspace="dtp")` → gets Level 1 (items, notes, brief)
+2. Agent sees `memory_tags: ["mir", "dtp"]` in workspace config
+3. Agent calls `memory_search(tags=["mir"])` → gets Level 2 (deep context)
+
+The orchestrator **never** calls memory service directly. It provides the tags; the agent decides when to fetch deeper context.
+
+## Subagent Usage
+
+When spawning a subagent for a workspace task:
+
+1. Call `get_context(workspace="name")` for the task list and brief
+2. Pass `memory_tags` to the subagent so it can fetch relevant memories
+3. Include `conventions` in the subagent prompt for style consistency
+4. Reference `repos` for the subagent to know which codebases to work on
+
+## Examples
+
+### Work Project (dtp)
+
+```json
+{
+  "dtp": {
+    "tags": ["mir", "rer", "dtp"],
+    "memory_tags": ["mir", "dtp", "dataprev"],
+    "repos": ["~/git/task-orchestrator-py", "~/git/mir-frontend"],
+    "conventions": "Python 3.11+, pytest, ruff. PRs required. Conventional commits.",
+    "description": "Dataprev work projects — MIR (Jenkins MCP), RER (React migration), task-orchestrator."
+  }
+}
+```
+
+### Personal Project (pessoal)
+
+```json
+{
+  "pessoal": {
+    "tags": ["papo-saude", "finance", "home"],
+    "memory_tags": ["pessoal", "health", "finance"],
+    "repos": ["~/git/papo-saude"],
+    "conventions": "TypeScript, Next.js 14, Tailwind. Move fast, minimal tests.",
+    "description": "Personal projects — health tracker, finance tools, home automation."
+  }
+}
+```
+
+### Infrastructure (infra)
+
+```json
+{
+  "infra": {
+    "tags": ["infra", "k8s", "ci"],
+    "memory_tags": ["infra", "kubernetes", "jenkins"],
+    "repos": ["~/git/infra-as-code", "~/git/jenkins-configs"],
+    "conventions": "Terraform, Helm charts, GitOps. Always plan before apply.",
+    "description": "Infrastructure — Kubernetes clusters, CI/CD pipelines, monitoring."
+  }
+}
+```
+
+## Tool Usage
+
+```
+# Create workspace
+manage_workspaces(operation="create", name="dtp", tags="mir,rer", memory_tags="mir,dtp", repos="~/git/mir", conventions="Python 3.11+", description="Work projects")
+
+# Update workspace
+manage_workspaces(operation="update", name="dtp", description="Updated description")
+
+# List all
+manage_workspaces(operation="list")
+
+# Delete
+manage_workspaces(operation="delete", name="dtp")
+```

--- a/src/task_orchestrator/db.py
+++ b/src/task_orchestrator/db.py
@@ -69,28 +69,29 @@ CREATE INDEX IF NOT EXISTS idx_due_at ON work_items(due_at) WHERE due_at IS NOT 
 """
 
 MIGRATIONS = [
-    ("previous_status",
-     "ALTER TABLE work_items ADD COLUMN previous_status TEXT DEFAULT NULL"),
-    ("unblock_at",
-     "ALTER TABLE dependencies ADD COLUMN unblock_at TEXT NOT NULL DEFAULT 'done'"),
-    ("summary",
-     "ALTER TABLE work_items ADD COLUMN summary TEXT DEFAULT ''"),
-    ("status_label",
-     "ALTER TABLE work_items ADD COLUMN status_label TEXT DEFAULT NULL"),
-    ("complexity",
-     "ALTER TABLE work_items ADD COLUMN complexity INTEGER DEFAULT NULL"),
-    ("metadata",
-     "ALTER TABLE work_items ADD COLUMN metadata TEXT DEFAULT NULL"),
-    ("properties",
-     "ALTER TABLE work_items ADD COLUMN properties TEXT DEFAULT NULL"),
-    ("role_changed_at",
-     "ALTER TABLE work_items ADD COLUMN role_changed_at TEXT DEFAULT NULL"),
-    ("due_at",
-     "ALTER TABLE work_items ADD COLUMN due_at TEXT DEFAULT NULL"),
-    ("schedule",
-     "ALTER TABLE work_items ADD COLUMN schedule TEXT DEFAULT NULL"),
-    ("next_run_at",
-     "ALTER TABLE work_items ADD COLUMN next_run_at TEXT DEFAULT NULL"),
+    (
+        "previous_status",
+        "ALTER TABLE work_items ADD COLUMN previous_status TEXT DEFAULT NULL",
+    ),
+    (
+        "unblock_at",
+        "ALTER TABLE dependencies ADD COLUMN unblock_at TEXT NOT NULL DEFAULT 'done'",
+    ),
+    ("summary", "ALTER TABLE work_items ADD COLUMN summary TEXT DEFAULT ''"),
+    (
+        "status_label",
+        "ALTER TABLE work_items ADD COLUMN status_label TEXT DEFAULT NULL",
+    ),
+    ("complexity", "ALTER TABLE work_items ADD COLUMN complexity INTEGER DEFAULT NULL"),
+    ("metadata", "ALTER TABLE work_items ADD COLUMN metadata TEXT DEFAULT NULL"),
+    ("properties", "ALTER TABLE work_items ADD COLUMN properties TEXT DEFAULT NULL"),
+    (
+        "role_changed_at",
+        "ALTER TABLE work_items ADD COLUMN role_changed_at TEXT DEFAULT NULL",
+    ),
+    ("due_at", "ALTER TABLE work_items ADD COLUMN due_at TEXT DEFAULT NULL"),
+    ("schedule", "ALTER TABLE work_items ADD COLUMN schedule TEXT DEFAULT NULL"),
+    ("next_run_at", "ALTER TABLE work_items ADD COLUMN next_run_at TEXT DEFAULT NULL"),
 ]
 
 

--- a/src/task_orchestrator/engine.py
+++ b/src/task_orchestrator/engine.py
@@ -10,7 +10,13 @@ import uuid
 from datetime import datetime, timezone, timedelta
 
 from .db import get_connection
-from .schemas import check_gate, should_skip_review, can_cancel, get_schema_for_item, should_auto_reopen
+from .schemas import (
+    check_gate,
+    should_skip_review,
+    can_cancel,
+    get_schema_for_item,
+    should_auto_reopen,
+)
 
 from croniter import croniter, CroniterBadCronError
 
@@ -21,7 +27,14 @@ VALID_STATUSES = {"queue", "work", "review", "done", "blocked", "cancelled"}
 
 class ToolError(Exception):
     """Structured error with code, field, and message."""
-    CODES = {"NOT_FOUND", "VALIDATION", "CONFLICT", "DEPENDENCY_UNSATISFIED", "GATE_BLOCKED"}
+
+    CODES = {
+        "NOT_FOUND",
+        "VALIDATION",
+        "CONFLICT",
+        "DEPENDENCY_UNSATISFIED",
+        "GATE_BLOCKED",
+    }
 
     def __init__(self, code: str, message: str, field: str = ""):
         self.code = code
@@ -42,15 +55,21 @@ def resolve_short_id(prefix: str) -> str:
         raise ToolError("VALIDATION", "Short ID must be at least 4 characters", "id")
     conn = get_connection()
     try:
-        rows = conn.execute("SELECT id FROM work_items WHERE id LIKE ?", (f"{prefix}%",)).fetchall()
+        rows = conn.execute(
+            "SELECT id FROM work_items WHERE id LIKE ?", (f"{prefix}%",)
+        ).fetchall()
         if len(rows) == 0:
             raise ToolError("NOT_FOUND", f"No item matching prefix '{prefix}'", "id")
         if len(rows) > 1:
             ids = [r["id"] for r in rows]
-            raise ToolError("CONFLICT", f"Prefix '{prefix}' matches {len(ids)} items: {ids}", "id")
+            raise ToolError(
+                "CONFLICT", f"Prefix '{prefix}' matches {len(ids)} items: {ids}", "id"
+            )
         return rows[0]["id"]
     finally:
         conn.close()
+
+
 TERMINAL = {"done", "cancelled"}
 PRIORITIES = {"critical", "high", "medium", "low"}
 PRIORITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
@@ -59,7 +78,12 @@ TRANSITIONS = {
     "start": {"queue": "work", "work": "review", "review": "done"},
     "complete": {"queue": "done", "work": "done", "review": "done"},
     "block": {"queue": "blocked", "work": "blocked", "review": "blocked"},
-    "cancel": {"queue": "cancelled", "work": "cancelled", "review": "cancelled", "blocked": "cancelled"},
+    "cancel": {
+        "queue": "cancelled",
+        "work": "cancelled",
+        "review": "cancelled",
+        "blocked": "cancelled",
+    },
     "reopen": {"done": "queue", "cancelled": "queue"},
 }
 
@@ -86,7 +110,11 @@ def _row_to_dict(row) -> dict | None:
 
 def _validate_priority(priority: str):
     if priority and priority not in PRIORITIES:
-        raise ToolError("VALIDATION", f"Invalid priority: {priority}. Valid: {sorted(PRIORITIES)}", "priority")
+        raise ToolError(
+            "VALIDATION",
+            f"Invalid priority: {priority}. Valid: {sorted(PRIORITIES)}",
+            "priority",
+        )
 
 
 def _validate_due_at(due_at: str | None):
@@ -94,7 +122,11 @@ def _validate_due_at(due_at: str | None):
         try:
             datetime.fromisoformat(due_at)
         except (ValueError, TypeError):
-            raise ToolError("VALIDATION", f"Invalid due_at: {due_at}. Must be ISO 8601 datetime string.", "due_at")
+            raise ToolError(
+                "VALIDATION",
+                f"Invalid due_at: {due_at}. Must be ISO 8601 datetime string.",
+                "due_at",
+            )
 
 
 def _workspace_tag_filter(workspace: str | None) -> tuple[str, list[str]]:
@@ -110,41 +142,87 @@ def _workspace_tag_filter(workspace: str | None) -> tuple[str, list[str]]:
 
 # --- WorkItem CRUD ---
 
-def create_item(title: str, description: str = "", summary: str = "",
-                parent_id: str | None = None, priority: str = "medium",
-                complexity: int | None = None, item_type: str = "", tags: str = "",
-                metadata: str | None = None, properties: str | None = None,
-                due_at: str | None = None, schedule: str | None = None) -> dict:
+
+def create_item(
+    title: str,
+    description: str = "",
+    summary: str = "",
+    parent_id: str | None = None,
+    priority: str = "medium",
+    complexity: int | None = None,
+    item_type: str = "",
+    tags: str = "",
+    metadata: str | None = None,
+    properties: str | None = None,
+    due_at: str | None = None,
+    schedule: str | None = None,
+) -> dict:
     _validate_priority(priority)
     _validate_due_at(due_at)
     if complexity is not None and not (1 <= complexity <= 10):
-        raise ToolError("VALIDATION", f"Complexity must be 1-10, got {complexity}", "complexity")
+        raise ToolError(
+            "VALIDATION", f"Complexity must be 1-10, got {complexity}", "complexity"
+        )
     conn = get_connection()
     try:
         item_id = _uid()
         now = _now()
         if parent_id:
-            parent = conn.execute("SELECT id FROM work_items WHERE id=?", (parent_id,)).fetchone()
+            parent = conn.execute(
+                "SELECT id FROM work_items WHERE id=?", (parent_id,)
+            ).fetchone()
             if not parent:
-                raise ToolError("NOT_FOUND", f"Parent {parent_id} not found", "parent_id")
+                raise ToolError(
+                    "NOT_FOUND", f"Parent {parent_id} not found", "parent_id"
+                )
             depth = _get_depth(conn, parent_id)
             if depth >= 3:
-                raise ToolError("VALIDATION", f"Max depth 4 reached (parent at depth {depth})", "parent_id")
+                raise ToolError(
+                    "VALIDATION",
+                    f"Max depth 4 reached (parent at depth {depth})",
+                    "parent_id",
+                )
         next_run_at = None
         if schedule:
             try:
-                next_run_at = croniter(schedule, datetime.now(timezone.utc)).get_next(datetime).isoformat()
+                next_run_at = (
+                    croniter(schedule, datetime.now(timezone.utc))
+                    .get_next(datetime)
+                    .isoformat()
+                )
             except CroniterBadCronError:
-                raise ToolError("VALIDATION", f"Invalid cron expression: {schedule}", "schedule")
+                raise ToolError(
+                    "VALIDATION", f"Invalid cron expression: {schedule}", "schedule"
+                )
         conn.execute(
             """INSERT INTO work_items (id,parent_id,title,description,summary,status,priority,
                complexity,item_type,tags,metadata,properties,role_changed_at,due_at,schedule,next_run_at,created_at,updated_at)
                VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
-            (item_id, parent_id, title, description, summary, "queue", priority,
-             complexity, item_type, tags, metadata, properties, now, due_at, schedule, next_run_at, now, now),
+            (
+                item_id,
+                parent_id,
+                title,
+                description,
+                summary,
+                "queue",
+                priority,
+                complexity,
+                item_type,
+                tags,
+                metadata,
+                properties,
+                now,
+                due_at,
+                schedule,
+                next_run_at,
+                now,
+                now,
+            ),
         )
         conn.commit()
-        return _row_to_dict(conn.execute("SELECT * FROM work_items WHERE id=?", (item_id,)).fetchone())
+        return _row_to_dict(
+            conn.execute("SELECT * FROM work_items WHERE id=?", (item_id,)).fetchone()
+        )
     finally:
         conn.close()
 
@@ -170,22 +248,48 @@ def update_item(item_id: str, **fields) -> dict:
         _validate_due_at(fields["due_at"])
     if "complexity" in fields and fields["complexity"] is not None:
         if not (1 <= fields["complexity"] <= 10):
-            raise ToolError("VALIDATION", f"Complexity must be 1-10, got {fields['complexity']}", "complexity")
+            raise ToolError(
+                "VALIDATION",
+                f"Complexity must be 1-10, got {fields['complexity']}",
+                "complexity",
+            )
     conn = get_connection()
     try:
-        allowed = {"title", "description", "summary", "priority", "complexity",
-                   "item_type", "tags", "metadata", "properties", "due_at", "schedule"}
+        allowed = {
+            "title",
+            "description",
+            "summary",
+            "priority",
+            "complexity",
+            "item_type",
+            "tags",
+            "metadata",
+            "properties",
+            "due_at",
+            "schedule",
+        }
         updates = {k: v for k, v in fields.items() if k in allowed and v is not None}
         if not updates:
             raise ToolError("VALIDATION", "No valid fields to update")
         if "schedule" in updates:
             try:
-                updates["next_run_at"] = croniter(updates["schedule"], datetime.now(timezone.utc)).get_next(datetime).isoformat()
+                updates["next_run_at"] = (
+                    croniter(updates["schedule"], datetime.now(timezone.utc))
+                    .get_next(datetime)
+                    .isoformat()
+                )
             except CroniterBadCronError:
-                raise ToolError("VALIDATION", f"Invalid cron expression: {updates['schedule']}", "schedule")
+                raise ToolError(
+                    "VALIDATION",
+                    f"Invalid cron expression: {updates['schedule']}",
+                    "schedule",
+                )
         updates["updated_at"] = _now()
         set_clause = ", ".join(f"{k}=?" for k in updates)
-        conn.execute(f"UPDATE work_items SET {set_clause} WHERE id=?", (*updates.values(), item_id))
+        conn.execute(
+            f"UPDATE work_items SET {set_clause} WHERE id=?",
+            (*updates.values(), item_id),
+        )
         conn.commit()
         row = conn.execute("SELECT * FROM work_items WHERE id=?", (item_id,)).fetchone()
         if not row:
@@ -206,7 +310,11 @@ def delete_item(item_id: str, recursive: bool = False) -> dict:
                 "SELECT COUNT(*) as cnt FROM work_items WHERE parent_id=?", (item_id,)
             ).fetchone()["cnt"]
             if child_count > 0:
-                raise ToolError("VALIDATION", f"Item has {child_count} children. Use recursive=true to delete them.", "item_id")
+                raise ToolError(
+                    "VALIDATION",
+                    f"Item has {child_count} children. Use recursive=true to delete them.",
+                    "item_id",
+                )
         cur = conn.execute("DELETE FROM work_items WHERE id=?", (item_id,))
         conn.commit()
         result = {"deleted": cur.rowcount > 0}
@@ -238,7 +346,9 @@ def delete_items_batch(ids: list[str], recursive: bool = False) -> dict:
 
 def _delete_descendants(conn, parent_id: str) -> int:
     """Recursively delete all descendants, returns count deleted."""
-    children = conn.execute("SELECT id FROM work_items WHERE parent_id=?", (parent_id,)).fetchall()
+    children = conn.execute(
+        "SELECT id FROM work_items WHERE parent_id=?", (parent_id,)
+    ).fetchall()
     count = 0
     for child in children:
         count += _delete_descendants(conn, child["id"])
@@ -250,15 +360,22 @@ def _delete_descendants(conn, parent_id: str) -> int:
 def get_item(item_id: str) -> dict | None:
     conn = get_connection()
     try:
-        return _row_to_dict(conn.execute("SELECT * FROM work_items WHERE id=?", (item_id,)).fetchone())
+        return _row_to_dict(
+            conn.execute("SELECT * FROM work_items WHERE id=?", (item_id,)).fetchone()
+        )
     finally:
         conn.close()
 
 
-def query_items(status: str | None = None, parent_id: str | None = None,
-                priority: str | None = None, search: str | None = None,
-                tags: str | None = None,
-                limit: int = 50, offset: int = 0) -> list[dict]:
+def query_items(
+    status: str | None = None,
+    parent_id: str | None = None,
+    priority: str | None = None,
+    search: str | None = None,
+    tags: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[dict]:
     conn = get_connection()
     try:
         clauses, params = [], []
@@ -290,7 +407,7 @@ def query_items(status: str | None = None, parent_id: str | None = None,
             # Batch IN clause in chunks of 500 to avoid SQLITE_LIMIT_VARIABLE_NUMBER
             id_clauses = []
             for i in range(0, len(matched_ids), 500):
-                chunk = matched_ids[i:i + 500]
+                chunk = matched_ids[i : i + 500]
                 id_clauses.append(f"id IN ({','.join('?' for _ in chunk)})")
                 params.extend(chunk)
             clauses.append(f"({' OR '.join(id_clauses)})")
@@ -310,7 +427,7 @@ def _fts_search(conn, search: str) -> set[str]:
     try:
         fts_term = search.replace('"', '""')
         rows = conn.execute(
-            'SELECT id FROM items_fts WHERE items_fts MATCH ?',
+            "SELECT id FROM items_fts WHERE items_fts MATCH ?",
             (f'"{fts_term}" OR {fts_term}*',),
         ).fetchall()
         return {r["id"] for r in rows}
@@ -325,7 +442,10 @@ def _fts_search(conn, search: str) -> set[str]:
 def get_children(parent_id: str) -> list[dict]:
     conn = get_connection()
     try:
-        rows = conn.execute("SELECT * FROM work_items WHERE parent_id=? ORDER BY created_at", (parent_id,)).fetchall()
+        rows = conn.execute(
+            "SELECT * FROM work_items WHERE parent_id=? ORDER BY created_at",
+            (parent_id,),
+        ).fetchall()
         return [_row_to_dict(r) for r in rows]
     finally:
         conn.close()
@@ -338,10 +458,14 @@ def get_ancestors(item_id: str) -> list[dict]:
         ancestors = []
         current = item_id
         while current:
-            row = conn.execute("SELECT * FROM work_items WHERE id=?", (current,)).fetchone()
+            row = conn.execute(
+                "SELECT * FROM work_items WHERE id=?", (current,)
+            ).fetchone()
             if not row or not row["parent_id"]:
                 break
-            parent = conn.execute("SELECT * FROM work_items WHERE id=?", (row["parent_id"],)).fetchone()
+            parent = conn.execute(
+                "SELECT * FROM work_items WHERE id=?", (row["parent_id"],)
+            ).fetchone()
             if parent:
                 ancestors.append(_row_to_dict(parent))
                 current = parent["id"]
@@ -356,7 +480,9 @@ def _get_depth(conn, item_id: str) -> int:
     depth = 0
     current = item_id
     while current:
-        row = conn.execute("SELECT parent_id FROM work_items WHERE id=?", (current,)).fetchone()
+        row = conn.execute(
+            "SELECT parent_id FROM work_items WHERE id=?", (current,)
+        ).fetchone()
         if not row or not row["parent_id"]:
             break
         current = row["parent_id"]
@@ -366,9 +492,14 @@ def _get_depth(conn, item_id: str) -> int:
 
 # --- Workflow ---
 
+
 def advance_item(item_id: str, trigger: str) -> dict:
     if trigger not in TRANSITIONS and trigger not in ("resume", "hold"):
-        raise ToolError("VALIDATION", f"Invalid trigger: {trigger}. Valid: {list(TRANSITIONS.keys()) + ['resume', 'hold']}", "trigger")
+        raise ToolError(
+            "VALIDATION",
+            f"Invalid trigger: {trigger}. Valid: {list(TRANSITIONS.keys()) + ['resume', 'hold']}",
+            "trigger",
+        )
     # hold is alias for block
     if trigger == "hold":
         trigger = "block"
@@ -381,16 +512,24 @@ def advance_item(item_id: str, trigger: str) -> dict:
 
         if trigger == "resume":
             if current != "blocked":
-                raise ToolError("CONFLICT", f"Can only resume blocked items, current: {current}", "trigger")
+                raise ToolError(
+                    "CONFLICT",
+                    f"Can only resume blocked items, current: {current}",
+                    "trigger",
+                )
             new_status = row["previous_status"] or "work"
         elif trigger == "block":
             if current in TERMINAL or current == "blocked":
                 raise ToolError("CONFLICT", f"Cannot block from {current}", "trigger")
             new_status = "blocked"
-            conn.execute("UPDATE work_items SET previous_status=? WHERE id=?", (current, item_id))
+            conn.execute(
+                "UPDATE work_items SET previous_status=? WHERE id=?", (current, item_id)
+            )
         else:
             if current not in TRANSITIONS[trigger]:
-                raise ToolError("CONFLICT", f"Cannot {trigger} from {current}", "trigger")
+                raise ToolError(
+                    "CONFLICT", f"Cannot {trigger} from {current}", "trigger"
+                )
             new_status = TRANSITIONS[trigger][current]
 
         # Check dependencies for advancing triggers
@@ -398,45 +537,69 @@ def advance_item(item_id: str, trigger: str) -> dict:
             blockers = _get_unsatisfied_blockers(conn, item_id)
             if blockers:
                 titles = [b["title"] for b in blockers]
-                raise ToolError("DEPENDENCY_UNSATISFIED", f"Blocked by unfinished items: {', '.join(titles)}", "item_id")
+                raise ToolError(
+                    "DEPENDENCY_UNSATISFIED",
+                    f"Blocked by unfinished items: {', '.join(titles)}",
+                    "item_id",
+                )
 
         # Check note schema gates
         if trigger in ("start", "complete"):
             item_dict = _row_to_dict(row)
-            notes = [_row_to_dict(r) for r in conn.execute(
-                "SELECT * FROM notes WHERE item_id=?", (item_id,)).fetchall()]
+            notes = [
+                _row_to_dict(r)
+                for r in conn.execute(
+                    "SELECT * FROM notes WHERE item_id=?", (item_id,)
+                ).fetchall()
+            ]
             gate = check_gate(item_dict, notes, new_status)
             if not gate["can_advance"]:
                 missing_keys = [m["key"] for m in gate["missing"]]
-                raise ToolError("GATE_BLOCKED",
-                                f"Missing required notes: {', '.join(missing_keys)}"
-                                + (f". Hint: {gate['guidance']}" if gate["guidance"] else ""),
-                                "item_id")
+                raise ToolError(
+                    "GATE_BLOCKED",
+                    f"Missing required notes: {', '.join(missing_keys)}"
+                    + (f". Hint: {gate['guidance']}" if gate["guidance"] else ""),
+                    "item_id",
+                )
 
         # Check cancel permission (permanent lifecycle)
         if trigger == "cancel" and not can_cancel(_row_to_dict(row)):
-            raise ToolError("CONFLICT", "Cannot cancel: item has permanent lifecycle", "trigger")
+            raise ToolError(
+                "CONFLICT", "Cannot cancel: item has permanent lifecycle", "trigger"
+            )
 
         # Auto-skip review for 'auto' lifecycle
-        if trigger == "start" and new_status == "review" and should_skip_review(_row_to_dict(row)):
+        if (
+            trigger == "start"
+            and new_status == "review"
+            and should_skip_review(_row_to_dict(row))
+        ):
             new_status = "done"
 
         now = _now()
         status_label = "cancelled" if trigger == "cancel" else None
         conn.execute(
             "UPDATE work_items SET status=?, status_label=?, role_changed_at=?, updated_at=? WHERE id=?",
-            (new_status, status_label, now, now, item_id))
+            (new_status, status_label, now, now, item_id),
+        )
         conn.commit()
 
         # Scheduled item requeue: if completing and item has a schedule, requeue it
         if new_status == "done" and row["schedule"]:
-            new_next_run = croniter(row["schedule"], datetime.now(timezone.utc)).get_next(datetime).isoformat()
+            new_next_run = (
+                croniter(row["schedule"], datetime.now(timezone.utc))
+                .get_next(datetime)
+                .isoformat()
+            )
             conn.execute(
                 "UPDATE work_items SET status='queue', previous_status=NULL, next_run_at=?, updated_at=? WHERE id=?",
-                (new_next_run, now, item_id))
+                (new_next_run, now, item_id),
+            )
             conn.commit()
 
-        result = _row_to_dict(conn.execute("SELECT * FROM work_items WHERE id=?", (item_id,)).fetchone())
+        result = _row_to_dict(
+            conn.execute("SELECT * FROM work_items WHERE id=?", (item_id,)).fetchone()
+        )
 
         # Find items unblocked by this transition
         unblocked = []
@@ -445,11 +608,14 @@ def advance_item(item_id: str, trigger: str) -> dict:
 
         # Reopen cascade: if reopening, cascade parent from terminal to work
         if trigger == "reopen" and row["parent_id"]:
-            parent = conn.execute("SELECT * FROM work_items WHERE id=?", (row["parent_id"],)).fetchone()
+            parent = conn.execute(
+                "SELECT * FROM work_items WHERE id=?", (row["parent_id"],)
+            ).fetchone()
             if parent and parent["status"] in TERMINAL:
                 conn.execute(
                     "UPDATE work_items SET status='work', status_label=NULL, role_changed_at=?, updated_at=? WHERE id=?",
-                    (now, now, parent["id"]))
+                    (now, now, parent["id"]),
+                )
                 conn.commit()
                 result["parent_reopened"] = True
 
@@ -468,17 +634,35 @@ def advance_items_batch(transitions: list[dict]) -> dict:
     for t in transitions:
         try:
             result = advance_item(t["item_id"], t["trigger"])
-            results.append({"item_id": t["item_id"], "trigger": t["trigger"],
-                           "applied": True, "new_status": result["status"]})
+            results.append(
+                {
+                    "item_id": t["item_id"],
+                    "trigger": t["trigger"],
+                    "applied": True,
+                    "new_status": result["status"],
+                }
+            )
             all_unblocked.extend(result.get("unblocked_items", []))
             succeeded += 1
         except (ValueError, ToolError) as e:
-            results.append({"item_id": t["item_id"], "trigger": t["trigger"],
-                           "applied": False, "error": str(e)})
+            results.append(
+                {
+                    "item_id": t["item_id"],
+                    "trigger": t["trigger"],
+                    "applied": False,
+                    "error": str(e),
+                }
+            )
             failed += 1
-    return {"results": results, "summary": {"total": len(transitions),
-            "succeeded": succeeded, "failed": failed},
-            "all_unblocked_items": all_unblocked}
+    return {
+        "results": results,
+        "summary": {
+            "total": len(transitions),
+            "succeeded": succeeded,
+            "failed": failed,
+        },
+        "all_unblocked_items": all_unblocked,
+    }
 
 
 def get_next_status(item_id: str, trigger: str) -> dict:
@@ -493,8 +677,16 @@ def get_next_status(item_id: str, trigger: str) -> dict:
         current = row["status"]
         if trigger == "resume":
             if current != "blocked":
-                return {"can_advance": False, "reason": f"Can only resume blocked items, current: {current}"}
-            return {"can_advance": True, "current": current, "next": row["previous_status"] or "work", "trigger": trigger}
+                return {
+                    "can_advance": False,
+                    "reason": f"Can only resume blocked items, current: {current}",
+                }
+            return {
+                "can_advance": True,
+                "current": current,
+                "next": row["previous_status"] or "work",
+                "trigger": trigger,
+            }
         if current not in TRANSITIONS.get(trigger, {}):
             return {"can_advance": False, "reason": f"Cannot {trigger} from {current}"}
         # Check deps
@@ -502,20 +694,36 @@ def get_next_status(item_id: str, trigger: str) -> dict:
         if trigger in ("start", "complete") and current == "queue":
             blockers = _get_unsatisfied_blockers(conn, item_id)
         if blockers:
-            return {"can_advance": False, "reason": "Blocked by dependencies",
-                    "blockers": [{"id": b["id"], "title": b["title"]} for b in blockers]}
+            return {
+                "can_advance": False,
+                "reason": "Blocked by dependencies",
+                "blockers": [{"id": b["id"], "title": b["title"]} for b in blockers],
+            }
         # Check gates
         if trigger in ("start", "complete"):
             item_dict = _row_to_dict(row)
-            notes = [_row_to_dict(r) for r in conn.execute(
-                "SELECT * FROM notes WHERE item_id=?", (item_id,)).fetchall()]
+            notes = [
+                _row_to_dict(r)
+                for r in conn.execute(
+                    "SELECT * FROM notes WHERE item_id=?", (item_id,)
+                ).fetchall()
+            ]
             gate = check_gate(item_dict, notes, TRANSITIONS[trigger][current])
             if not gate["can_advance"]:
-                return {"can_advance": False, "reason": "Missing required notes",
-                        "missing": gate["missing"], "guidance": gate["guidance"]}
+                return {
+                    "can_advance": False,
+                    "reason": "Missing required notes",
+                    "missing": gate["missing"],
+                    "guidance": gate["guidance"],
+                }
         if trigger == "cancel" and not can_cancel(_row_to_dict(row)):
             return {"can_advance": False, "reason": "Item has permanent lifecycle"}
-        return {"can_advance": True, "current": current, "next": TRANSITIONS[trigger][current], "trigger": trigger}
+        return {
+            "can_advance": True,
+            "current": current,
+            "next": TRANSITIONS[trigger][current],
+            "trigger": trigger,
+        }
     finally:
         conn.close()
 
@@ -523,12 +731,22 @@ def get_next_status(item_id: str, trigger: str) -> dict:
 def _get_unsatisfied_blockers(conn, item_id: str) -> list[dict]:
     """Check blockers respecting unblock_at threshold. Ignores relates_to deps.
     Status order: queue(0) < work(1) < review(2) < done(3). cancelled counts as done."""
-    status_rank = {"queue": 0, "work": 1, "review": 2, "done": 3, "cancelled": 3, "blocked": 0}
-    rows = conn.execute("""
+    status_rank = {
+        "queue": 0,
+        "work": 1,
+        "review": 2,
+        "done": 3,
+        "cancelled": 3,
+        "blocked": 0,
+    }
+    rows = conn.execute(
+        """
         SELECT wi.*, d.unblock_at, d.dep_type FROM dependencies d
         JOIN work_items wi ON wi.id = d.from_id
         WHERE d.to_id = ?
-    """, (item_id,)).fetchall()
+    """,
+        (item_id,),
+    ).fetchall()
     unsatisfied = []
     for r in rows:
         dep_type = r["dep_type"] if "dep_type" in r.keys() else "blocks"
@@ -550,7 +768,9 @@ def _find_newly_unblocked(conn, completed_id: str) -> list[dict]:
     for dep in dependents:
         blockers = _get_unsatisfied_blockers(conn, dep["to_id"])
         if not blockers:
-            row = conn.execute("SELECT * FROM work_items WHERE id=?", (dep["to_id"],)).fetchone()
+            row = conn.execute(
+                "SELECT * FROM work_items WHERE id=?", (dep["to_id"],)
+            ).fetchone()
             if row and row["status"] not in TERMINAL:
                 unblocked.append(_row_to_dict(row))
     return unblocked
@@ -609,7 +829,11 @@ def get_next_item(workspace: str | None = None) -> dict | None:
             overdue = 1
             if x.get("due_at") and x["due_at"] <= now_iso:
                 overdue = 0
-            return (overdue, 0 if x["status"] == "work" else 1, PRIORITY_ORDER.get(x["priority"], 2))
+            return (
+                overdue,
+                0 if x["status"] == "work" else 1,
+                PRIORITY_ORDER.get(x["priority"], 2),
+            )
 
         candidates.sort(key=_sort_key)
         return candidates[0] if candidates else None
@@ -620,10 +844,14 @@ def get_next_item(workspace: str | None = None) -> dict | None:
 def get_blocked_items() -> list[dict]:
     conn = get_connection()
     try:
-        rows = conn.execute("SELECT * FROM work_items WHERE status='blocked'").fetchall()
+        rows = conn.execute(
+            "SELECT * FROM work_items WHERE status='blocked'"
+        ).fetchall()
         result = [_row_to_dict(r) for r in rows]
         # Also find queue items with unsatisfied deps
-        queue_rows = conn.execute("SELECT * FROM work_items WHERE status='queue'").fetchall()
+        queue_rows = conn.execute(
+            "SELECT * FROM work_items WHERE status='queue'"
+        ).fetchall()
         for r in queue_rows:
             blockers = _get_unsatisfied_blockers(conn, r["id"])
             if blockers:
@@ -635,22 +863,40 @@ def get_blocked_items() -> list[dict]:
         conn.close()
 
 
-def get_context(item_id: str | None = None, include_ancestors: bool = False, workspace: str | None = None) -> dict:
+def get_context(
+    item_id: str | None = None,
+    include_ancestors: bool = False,
+    workspace: str | None = None,
+) -> dict:
     conn = get_connection()
     try:
         if item_id:
-            row = conn.execute("SELECT * FROM work_items WHERE id=?", (item_id,)).fetchone()
+            row = conn.execute(
+                "SELECT * FROM work_items WHERE id=?", (item_id,)
+            ).fetchone()
             if not row:
                 raise ToolError("NOT_FOUND", f"Item {item_id} not found", "item_id")
             item = _row_to_dict(row)
-            children = [_row_to_dict(r) for r in conn.execute(
-                "SELECT * FROM work_items WHERE parent_id=?", (item_id,)).fetchall()]
-            notes = [_row_to_dict(r) for r in conn.execute(
-                "SELECT * FROM notes WHERE item_id=?", (item_id,)).fetchall()]
+            children = [
+                _row_to_dict(r)
+                for r in conn.execute(
+                    "SELECT * FROM work_items WHERE parent_id=?", (item_id,)
+                ).fetchall()
+            ]
+            notes = [
+                _row_to_dict(r)
+                for r in conn.execute(
+                    "SELECT * FROM notes WHERE item_id=?", (item_id,)
+                ).fetchall()
+            ]
             blockers = _get_unsatisfied_blockers(conn, item_id)
-            result = {"item": item, "children": children, "notes": notes,
-                      "blockers": [_row_to_dict(b) for b in blockers],
-                      "can_advance": len(blockers) == 0 and item["status"] not in TERMINAL}
+            result = {
+                "item": item,
+                "children": children,
+                "notes": notes,
+                "blockers": [_row_to_dict(b) for b in blockers],
+                "can_advance": len(blockers) == 0 and item["status"] not in TERMINAL,
+            }
             if include_ancestors:
                 result["ancestors"] = get_ancestors(item_id)
             # Add gate info if schema exists
@@ -670,15 +916,24 @@ def get_context(item_id: str | None = None, include_ancestors: bool = False, wor
 
         counts = {}
         for row in conn.execute(
-            f"SELECT status, COUNT(*) as cnt FROM work_items {ws_where} GROUP BY status", ws_params
+            f"SELECT status, COUNT(*) as cnt FROM work_items {ws_where} GROUP BY status",
+            ws_params,
         ).fetchall():
             counts[row["status"]] = row["cnt"]
-        active = [_row_to_dict(r) for r in conn.execute(
-            f"SELECT * FROM work_items WHERE status IN ('work','review') {ws_and} ORDER BY updated_at DESC LIMIT 10",
-            ws_params).fetchall()]
-        recent = [_row_to_dict(r) for r in conn.execute(
-            f"SELECT * FROM work_items WHERE status IN ('done','cancelled') {ws_and} ORDER BY updated_at DESC LIMIT 5",
-            ws_params).fetchall()]
+        active = [
+            _row_to_dict(r)
+            for r in conn.execute(
+                f"SELECT * FROM work_items WHERE status IN ('work','review') {ws_and} ORDER BY updated_at DESC LIMIT 10",
+                ws_params,
+            ).fetchall()
+        ]
+        recent = [
+            _row_to_dict(r)
+            for r in conn.execute(
+                f"SELECT * FROM work_items WHERE status IN ('done','cancelled') {ws_and} ORDER BY updated_at DESC LIMIT 5",
+                ws_params,
+            ).fetchall()
+        ]
         blocked = get_blocked_items()
         next_item = get_next_item(workspace=workspace)
         # Stale item detection
@@ -691,41 +946,64 @@ def get_context(item_id: str | None = None, include_ancestors: bool = False, wor
             item = _row_to_dict(row)
             updated = _parse_dt(item["updated_at"])
             days = (now_dt - updated).days
-            if (item["status"] == "queue" and days > 7) or (item["status"] == "work" and days > 3):
+            if (item["status"] == "queue" and days > 7) or (
+                item["status"] == "work" and days > 3
+            ):
                 item["stale_days"] = days
                 stale_items.append(item)
-        return {"counts": counts, "active": active, "blocked": blocked,
-                "recent_completed": recent, "next_item": next_item,
-                "stale_items": stale_items,
-                "due_soon": _get_items_by_due_date(conn, "due_soon", now_dt),
-                "overdue": _get_items_by_due_date(conn, "overdue", now_dt),
-                "scheduled_upcoming": _get_scheduled_upcoming(conn, now_dt)}
+        return {
+            "counts": counts,
+            "active": active,
+            "blocked": blocked,
+            "recent_completed": recent,
+            "next_item": next_item,
+            "stale_items": stale_items,
+            "due_soon": _get_items_by_due_date(conn, "due_soon", now_dt),
+            "overdue": _get_items_by_due_date(conn, "overdue", now_dt),
+            "scheduled_upcoming": _get_scheduled_upcoming(conn, now_dt),
+        }
     finally:
         conn.close()
 
 
 # --- Notes ---
 
+
 def upsert_note(item_id: str, key: str, body: str, role: str = "queue") -> dict:
     conn = get_connection()
     try:
-        item = conn.execute("SELECT * FROM work_items WHERE id=?", (item_id,)).fetchone()
+        item = conn.execute(
+            "SELECT * FROM work_items WHERE id=?", (item_id,)
+        ).fetchone()
         if not item:
             raise ToolError("NOT_FOUND", f"Item {item_id} not found", "item_id")
         now = _now()
-        existing = conn.execute("SELECT id FROM notes WHERE item_id=? AND key=?", (item_id, key)).fetchone()
+        existing = conn.execute(
+            "SELECT id FROM notes WHERE item_id=? AND key=?", (item_id, key)
+        ).fetchone()
         if existing:
-            conn.execute("UPDATE notes SET body=?, role=?, updated_at=? WHERE id=?",
-                          (body, role, now, existing["id"]))
+            conn.execute(
+                "UPDATE notes SET body=?, role=?, updated_at=? WHERE id=?",
+                (body, role, now, existing["id"]),
+            )
         else:
-            conn.execute("INSERT INTO notes (id,item_id,key,role,body,created_at,updated_at) VALUES (?,?,?,?,?,?,?)",
-                          (_uid(), item_id, key, role, body, now, now))
+            conn.execute(
+                "INSERT INTO notes (id,item_id,key,role,body,created_at,updated_at) VALUES (?,?,?,?,?,?,?)",
+                (_uid(), item_id, key, role, body, now, now),
+            )
         conn.commit()
-        result = _row_to_dict(conn.execute("SELECT * FROM notes WHERE item_id=? AND key=?", (item_id, key)).fetchone())
+        result = _row_to_dict(
+            conn.execute(
+                "SELECT * FROM notes WHERE item_id=? AND key=?", (item_id, key)
+            ).fetchone()
+        )
         # Auto-reopen: if item is terminal and schema has auto-reopen lifecycle
         item_dict = _row_to_dict(item)
         if item_dict["status"] in TERMINAL and should_auto_reopen(item_dict):
-            conn.execute("UPDATE work_items SET status='queue', updated_at=? WHERE id=?", (now, item_id))
+            conn.execute(
+                "UPDATE work_items SET status='queue', updated_at=? WHERE id=?",
+                (now, item_id),
+            )
             conn.commit()
             result["auto_reopened"] = True
         return result
@@ -736,7 +1014,9 @@ def upsert_note(item_id: str, key: str, body: str, role: str = "queue") -> dict:
 def delete_note(item_id: str, key: str) -> bool:
     conn = get_connection()
     try:
-        cur = conn.execute("DELETE FROM notes WHERE item_id=? AND key=?", (item_id, key))
+        cur = conn.execute(
+            "DELETE FROM notes WHERE item_id=? AND key=?", (item_id, key)
+        )
         conn.commit()
         return cur.rowcount > 0
     finally:
@@ -747,7 +1027,9 @@ def get_notes(item_id: str, include_body: bool = True) -> list[dict]:
     conn = get_connection()
     try:
         if include_body:
-            rows = conn.execute("SELECT * FROM notes WHERE item_id=? ORDER BY created_at", (item_id,)).fetchall()
+            rows = conn.execute(
+                "SELECT * FROM notes WHERE item_id=? ORDER BY created_at", (item_id,)
+            ).fetchall()
         else:
             rows = conn.execute(
                 "SELECT id, item_id, key, role, created_at, updated_at FROM notes WHERE item_id=? ORDER BY created_at",
@@ -760,8 +1042,10 @@ def get_notes(item_id: str, include_body: bool = True) -> list[dict]:
 
 # --- Dependencies ---
 
-def add_dependency(from_id: str, to_id: str, dep_type: str = "blocks",
-                   unblock_at: str = "done") -> dict:
+
+def add_dependency(
+    from_id: str, to_id: str, dep_type: str = "blocks", unblock_at: str = "done"
+) -> dict:
     """Add dependency. dep_type: blocks, is_blocked_by, relates_to.
     unblock_at: status at which the blocker unblocks (default: done).
     Valid: done, review, work. RELATES_TO deps cannot have unblock_at."""
@@ -770,12 +1054,24 @@ def add_dependency(from_id: str, to_id: str, dep_type: str = "blocks",
     valid_types = {"blocks", "is_blocked_by", "relates_to"}
     dep_type = dep_type.lower().replace("-", "_")
     if dep_type not in valid_types:
-        raise ToolError("VALIDATION", f"Invalid dep_type: {dep_type}. Valid: {sorted(valid_types)}", "dep_type")
+        raise ToolError(
+            "VALIDATION",
+            f"Invalid dep_type: {dep_type}. Valid: {sorted(valid_types)}",
+            "dep_type",
+        )
     if dep_type == "relates_to" and unblock_at != "done":
-        raise ToolError("VALIDATION", "RELATES_TO dependencies cannot have unblock_at threshold", "unblock_at")
+        raise ToolError(
+            "VALIDATION",
+            "RELATES_TO dependencies cannot have unblock_at threshold",
+            "unblock_at",
+        )
     valid_unblock = {"done", "review", "work"}
     if unblock_at not in valid_unblock:
-        raise ToolError("VALIDATION", f"Invalid unblock_at: {unblock_at}. Valid: {sorted(valid_unblock)}", "unblock_at")
+        raise ToolError(
+            "VALIDATION",
+            f"Invalid unblock_at: {unblock_at}. Valid: {sorted(valid_unblock)}",
+            "unblock_at",
+        )
     # IS_BLOCKED_BY is stored as BLOCKS with swapped direction
     if dep_type == "is_blocked_by":
         from_id, to_id = to_id, from_id
@@ -783,19 +1079,27 @@ def add_dependency(from_id: str, to_id: str, dep_type: str = "blocks",
     conn = get_connection()
     try:
         for fid in (from_id, to_id):
-            if not conn.execute("SELECT id FROM work_items WHERE id=?", (fid,)).fetchone():
+            if not conn.execute(
+                "SELECT id FROM work_items WHERE id=?", (fid,)
+            ).fetchone():
                 raise ToolError("NOT_FOUND", f"Item {fid} not found", "from_id")
         if dep_type != "relates_to" and _would_create_cycle(conn, from_id, to_id):
             raise ToolError("CONFLICT", "Dependency would create a cycle", "from_id")
         dep_id = _uid()
         now = _now()
         try:
-            conn.execute("INSERT INTO dependencies (id,from_id,to_id,dep_type,unblock_at,created_at) VALUES (?,?,?,?,?,?)",
-                          (dep_id, from_id, to_id, dep_type, unblock_at, now))
+            conn.execute(
+                "INSERT INTO dependencies (id,from_id,to_id,dep_type,unblock_at,created_at) VALUES (?,?,?,?,?,?)",
+                (dep_id, from_id, to_id, dep_type, unblock_at, now),
+            )
             conn.commit()
         except sqlite3.IntegrityError:
-            raise ToolError("CONFLICT", f"Dependency {from_id} → {to_id} already exists", "from_id")
-        return _row_to_dict(conn.execute("SELECT * FROM dependencies WHERE id=?", (dep_id,)).fetchone())
+            raise ToolError(
+                "CONFLICT", f"Dependency {from_id} → {to_id} already exists", "from_id"
+            )
+        return _row_to_dict(
+            conn.execute("SELECT * FROM dependencies WHERE id=?", (dep_id,)).fetchone()
+        )
     finally:
         conn.close()
 
@@ -803,7 +1107,9 @@ def add_dependency(from_id: str, to_id: str, dep_type: str = "blocks",
 def add_dependency_pattern(item_ids: list[str], pattern: str = "linear") -> list[dict]:
     """Create dependencies using pattern shortcuts: linear, fan-out, fan-in."""
     if len(item_ids) < 2:
-        raise ToolError("VALIDATION", "Need at least 2 items for a dependency pattern", "item_ids")
+        raise ToolError(
+            "VALIDATION", "Need at least 2 items for a dependency pattern", "item_ids"
+        )
     results = []
     if pattern == "linear":
         for i in range(len(item_ids) - 1):
@@ -817,14 +1123,20 @@ def add_dependency_pattern(item_ids: list[str], pattern: str = "linear") -> list
         for source in item_ids[:-1]:
             results.append(add_dependency(source, target))
     else:
-        raise ToolError("VALIDATION", f"Invalid pattern: {pattern}. Valid: linear, fan-out, fan-in", "pattern")
+        raise ToolError(
+            "VALIDATION",
+            f"Invalid pattern: {pattern}. Valid: linear, fan-out, fan-in",
+            "pattern",
+        )
     return results
 
 
 def remove_dependency(from_id: str, to_id: str) -> bool:
     conn = get_connection()
     try:
-        cur = conn.execute("DELETE FROM dependencies WHERE from_id=? AND to_id=?", (from_id, to_id))
+        cur = conn.execute(
+            "DELETE FROM dependencies WHERE from_id=? AND to_id=?", (from_id, to_id)
+        )
         conn.commit()
         return cur.rowcount > 0
     finally:
@@ -837,23 +1149,31 @@ def get_dependencies(item_id: str, direction: str = "both") -> dict:
         blocks = []
         blocked_by = []
         if direction in ("outbound", "both"):
-            rows = conn.execute("""
+            rows = conn.execute(
+                """
                 SELECT d.*, wi.title as to_title, wi.status as to_status
                 FROM dependencies d JOIN work_items wi ON wi.id=d.to_id WHERE d.from_id=?
-            """, (item_id,)).fetchall()
+            """,
+                (item_id,),
+            ).fetchall()
             blocks = [_row_to_dict(r) for r in rows]
         if direction in ("inbound", "both"):
-            rows = conn.execute("""
+            rows = conn.execute(
+                """
                 SELECT d.*, wi.title as from_title, wi.status as from_status
                 FROM dependencies d JOIN work_items wi ON wi.id=d.from_id WHERE d.to_id=?
-            """, (item_id,)).fetchall()
+            """,
+                (item_id,),
+            ).fetchall()
             blocked_by = [_row_to_dict(r) for r in rows]
         return {"blocks": blocks, "blocked_by": blocked_by}
     finally:
         conn.close()
 
 
-def query_dependencies_bfs(item_id: str, direction: str = "outbound", max_depth: int = 10) -> list[dict]:
+def query_dependencies_bfs(
+    item_id: str, direction: str = "outbound", max_depth: int = 10
+) -> list[dict]:
     """BFS traversal of dependency graph."""
     conn = get_connection()
     try:
@@ -866,20 +1186,26 @@ def query_dependencies_bfs(item_id: str, direction: str = "outbound", max_depth:
                 continue
             visited.add(current)
             if direction == "outbound":
-                rows = conn.execute("""
+                rows = conn.execute(
+                    """
                     SELECT d.*, wi.title, wi.status, wi.priority
                     FROM dependencies d JOIN work_items wi ON wi.id=d.to_id WHERE d.from_id=?
-                """, (current,)).fetchall()
+                """,
+                    (current,),
+                ).fetchall()
                 for r in rows:
                     item = _row_to_dict(r)
                     item["depth"] = depth + 1
                     result.append(item)
                     queue.append((r["to_id"], depth + 1))
             else:
-                rows = conn.execute("""
+                rows = conn.execute(
+                    """
                     SELECT d.*, wi.title, wi.status, wi.priority
                     FROM dependencies d JOIN work_items wi ON wi.id=d.from_id WHERE d.to_id=?
-                """, (current,)).fetchall()
+                """,
+                    (current,),
+                ).fetchall()
                 for r in rows:
                     item = _row_to_dict(r)
                     item["depth"] = depth + 1
@@ -900,20 +1226,26 @@ def _would_create_cycle(conn, from_id: str, to_id: str) -> bool:
         if current in visited:
             continue
         visited.add(current)
-        rows = conn.execute("SELECT to_id FROM dependencies WHERE from_id=?", (current,)).fetchall()
+        rows = conn.execute(
+            "SELECT to_id FROM dependencies WHERE from_id=?", (current,)
+        ).fetchall()
         queue.extend(r["to_id"] for r in rows)
     return False
 
 
 # --- Bulk ---
 
-def create_work_tree(root: dict, children: list[dict] | None = None,
-                     deps: list[dict] | None = None,
-                     create_notes: bool = False) -> dict:
+
+def create_work_tree(
+    root: dict,
+    children: list[dict] | None = None,
+    deps: list[dict] | None = None,
+    create_notes: bool = False,
+) -> dict:
     root_item = create_item(**root)
     ref_map = {"root": root_item["id"]}
     created = [root_item]
-    for child in (children or []):
+    for child in children or []:
         ref = child.pop("ref", None)
         child["parent_id"] = root_item["id"]
         item = create_item(**child)
@@ -921,24 +1253,44 @@ def create_work_tree(root: dict, children: list[dict] | None = None,
             ref_map[ref] = item["id"]
         created.append(item)
     dep_results = []
-    for dep in (deps or []):
+    for dep in deps or []:
         fid = ref_map.get(dep["from"], dep["from"])
         tid = ref_map.get(dep["to"], dep["to"])
-        dep_results.append(add_dependency(fid, tid,
-                                          dep_type=dep.get("type", "blocks"),
-                                          unblock_at=dep.get("unblock_at", "done")))
+        dep_results.append(
+            add_dependency(
+                fid,
+                tid,
+                dep_type=dep.get("type", "blocks"),
+                unblock_at=dep.get("unblock_at", "done"),
+            )
+        )
     # Auto-create blank notes from schemas
     notes_created = []
     if create_notes:
         for item in created:
-            schema = get_schema_for_item(item.get("item_type", ""), item.get("tags", ""))
+            schema = get_schema_for_item(
+                item.get("item_type", ""), item.get("tags", "")
+            )
             if schema:
                 for note_def in schema["notes"]:
-                    note = upsert_note(item["id"], note_def["key"], "", note_def["role"])
-                    notes_created.append({"item_id": item["id"], "key": note_def["key"],
-                                         "role": note_def["role"], "id": note["id"]})
-    return {"root": root_item, "children": created[1:], "dependencies": dep_results,
-            "ref_map": ref_map, "notes": notes_created}
+                    note = upsert_note(
+                        item["id"], note_def["key"], "", note_def["role"]
+                    )
+                    notes_created.append(
+                        {
+                            "item_id": item["id"],
+                            "key": note_def["key"],
+                            "role": note_def["role"],
+                            "id": note["id"],
+                        }
+                    )
+    return {
+        "root": root_item,
+        "children": created[1:],
+        "dependencies": dep_results,
+        "ref_map": ref_map,
+        "notes": notes_created,
+    }
 
 
 def complete_tree(parent_id: str) -> dict:
@@ -948,7 +1300,9 @@ def complete_tree(parent_id: str) -> dict:
         # Get all descendants
         def _get_all_descendants(pid):
             items = []
-            rows = conn.execute("SELECT * FROM work_items WHERE parent_id=?", (pid,)).fetchall()
+            rows = conn.execute(
+                "SELECT * FROM work_items WHERE parent_id=?", (pid,)
+            ).fetchall()
             for r in rows:
                 items.append(_row_to_dict(r))
                 items.extend(_get_all_descendants(r["id"]))
@@ -959,19 +1313,30 @@ def complete_tree(parent_id: str) -> dict:
         skipped = []
         for item in descendants:
             if item["status"] in TERMINAL:
-                skipped.append({"id": item["id"], "title": item["title"], "status": item["status"]})
+                skipped.append(
+                    {"id": item["id"], "title": item["title"], "status": item["status"]}
+                )
                 continue
             try:
                 result = advance_item(item["id"], "complete")
-                completed.append({"id": item["id"], "title": item["title"], "new_status": result["status"]})
+                completed.append(
+                    {
+                        "id": item["id"],
+                        "title": item["title"],
+                        "new_status": result["status"],
+                    }
+                )
             except ValueError as e:
-                skipped.append({"id": item["id"], "title": item["title"], "reason": str(e)})
+                skipped.append(
+                    {"id": item["id"], "title": item["title"], "reason": str(e)}
+                )
         return {"completed": completed, "skipped": skipped}
     finally:
         conn.close()
 
 
 # --- Metrics ---
+
 
 def get_metrics(days: int = 30, workspace: str | None = None) -> dict:
     """Work metrics: throughput, lead time, WIP, stale ratio, breakdowns."""
@@ -1004,7 +1369,9 @@ def get_metrics(days: int = 30, workspace: str | None = None) -> dict:
         ).fetchall()
         if lt_rows:
             total_secs = sum(
-                (_parse_dt(r["updated_at"]) - _parse_dt(r["created_at"])).total_seconds()
+                (
+                    _parse_dt(r["updated_at"]) - _parse_dt(r["created_at"])
+                ).total_seconds()
                 for r in lt_rows
             )
             lead_time_avg = total_secs / len(lt_rows)
@@ -1012,7 +1379,10 @@ def get_metrics(days: int = 30, workspace: str | None = None) -> dict:
             lead_time_avg = 0.0
 
         # WIP
-        wip = conn.execute(f"SELECT COUNT(*) as cnt FROM work_items WHERE status='work' {ws_and}", ws_params).fetchone()["cnt"]
+        wip = conn.execute(
+            f"SELECT COUNT(*) as cnt FROM work_items WHERE status='work' {ws_and}",
+            ws_params,
+        ).fetchone()["cnt"]
 
         # Stale ratio
         non_terminal = conn.execute(
@@ -1048,7 +1418,9 @@ def get_metrics(days: int = 30, workspace: str | None = None) -> dict:
 
         # Total items
         ws_where = f"WHERE {ws_clause}" if ws_clause else ""
-        total = conn.execute(f"SELECT COUNT(*) as cnt FROM work_items {ws_where}", ws_params).fetchone()["cnt"]
+        total = conn.execute(
+            f"SELECT COUNT(*) as cnt FROM work_items {ws_where}", ws_params
+        ).fetchone()["cnt"]
 
         return {
             "throughput_per_week": throughput,
@@ -1066,13 +1438,21 @@ def get_metrics(days: int = 30, workspace: str | None = None) -> dict:
 
 # --- Export / Import ---
 
+
 def export_graph() -> dict:
     """Export all items, notes, and dependencies as a JSON-serializable dict."""
     conn = get_connection()
     try:
-        items = [_row_to_dict(r) for r in conn.execute("SELECT * FROM work_items").fetchall()]
-        notes = [_row_to_dict(r) for r in conn.execute("SELECT * FROM notes").fetchall()]
-        deps = [_row_to_dict(r) for r in conn.execute("SELECT * FROM dependencies").fetchall()]
+        items = [
+            _row_to_dict(r) for r in conn.execute("SELECT * FROM work_items").fetchall()
+        ]
+        notes = [
+            _row_to_dict(r) for r in conn.execute("SELECT * FROM notes").fetchall()
+        ]
+        deps = [
+            _row_to_dict(r)
+            for r in conn.execute("SELECT * FROM dependencies").fetchall()
+        ]
         return {
             "items": items,
             "notes": notes,
@@ -1115,7 +1495,9 @@ def import_graph(data: dict, mode: str = "merge") -> dict:
     mode='replace': delete everything first, then insert all.
     """
     if mode not in ("merge", "replace"):
-        raise ToolError("VALIDATION", f"Invalid mode: {mode}. Valid: merge, replace", "mode")
+        raise ToolError(
+            "VALIDATION", f"Invalid mode: {mode}. Valid: merge, replace", "mode"
+        )
     conn = get_connection()
     try:
         if mode == "replace":
@@ -1130,9 +1512,13 @@ def import_graph(data: dict, mode: str = "merge") -> dict:
         _insert_rows(conn, "dependencies", data.get("dependencies", []))
         conn.commit()
         counts = {
-            "items": conn.execute("SELECT COUNT(*) as c FROM work_items").fetchone()["c"],
+            "items": conn.execute("SELECT COUNT(*) as c FROM work_items").fetchone()[
+                "c"
+            ],
             "notes": conn.execute("SELECT COUNT(*) as c FROM notes").fetchone()["c"],
-            "dependencies": conn.execute("SELECT COUNT(*) as c FROM dependencies").fetchone()["c"],
+            "dependencies": conn.execute(
+                "SELECT COUNT(*) as c FROM dependencies"
+            ).fetchone()["c"],
         }
         return {"imported": True, "mode": mode, "counts": counts}
     finally:

--- a/src/task_orchestrator/engine.py
+++ b/src/task_orchestrator/engine.py
@@ -14,6 +14,8 @@ from .schemas import check_gate, should_skip_review, can_cancel, get_schema_for_
 
 from croniter import croniter, CroniterBadCronError
 
+from .workspace import get_workspace_tags
+
 VALID_STATUSES = {"queue", "work", "review", "done", "blocked", "cancelled"}
 
 
@@ -93,6 +95,17 @@ def _validate_due_at(due_at: str | None):
             datetime.fromisoformat(due_at)
         except (ValueError, TypeError):
             raise ToolError("VALIDATION", f"Invalid due_at: {due_at}. Must be ISO 8601 datetime string.", "due_at")
+
+
+def _workspace_tag_filter(workspace: str | None) -> tuple[str, list[str]]:
+    """Return (SQL clause, params) to filter items by workspace tags. Empty if no workspace."""
+    if not workspace:
+        return "", []
+    tags = get_workspace_tags(workspace)
+    if tags is None:
+        raise ToolError("NOT_FOUND", f"Workspace '{workspace}' not found", "workspace")
+    clauses = " OR ".join("tags LIKE ?" for _ in tags)
+    return f"({clauses})", [f"%{t}%" for t in tags]
 
 
 # --- WorkItem CRUD ---
@@ -570,11 +583,16 @@ def _get_scheduled_upcoming(conn, now_dt: datetime) -> list[dict]:
     return [_row_to_dict(r) for r in rows]
 
 
-def get_next_item() -> dict | None:
+def get_next_item(workspace: str | None = None) -> dict | None:
     conn = get_connection()
     try:
+        ws_clause, ws_params = _workspace_tag_filter(workspace)
+        where = "WHERE status IN ('queue','work')"
+        if ws_clause:
+            where += f" AND {ws_clause}"
         rows = conn.execute(
-            "SELECT * FROM work_items WHERE status IN ('queue','work') ORDER BY status ASC, created_at ASC",
+            f"SELECT * FROM work_items {where} ORDER BY status ASC, created_at ASC",
+            ws_params,
         ).fetchall()
         now_iso = _now()
         candidates = []
@@ -617,7 +635,7 @@ def get_blocked_items() -> list[dict]:
         conn.close()
 
 
-def get_context(item_id: str | None = None, include_ancestors: bool = False) -> dict:
+def get_context(item_id: str | None = None, include_ancestors: bool = False, workspace: str | None = None) -> dict:
     conn = get_connection()
     try:
         if item_id:
@@ -646,20 +664,29 @@ def get_context(item_id: str | None = None, include_ancestors: bool = False) -> 
                     result["guidance"] = gate["guidance"]
             return result
         # Global context
+        ws_clause, ws_params = _workspace_tag_filter(workspace)
+        ws_where = f"WHERE {ws_clause}" if ws_clause else ""
+        ws_and = f"AND {ws_clause}" if ws_clause else ""
+
         counts = {}
-        for row in conn.execute("SELECT status, COUNT(*) as cnt FROM work_items GROUP BY status").fetchall():
+        for row in conn.execute(
+            f"SELECT status, COUNT(*) as cnt FROM work_items {ws_where} GROUP BY status", ws_params
+        ).fetchall():
             counts[row["status"]] = row["cnt"]
         active = [_row_to_dict(r) for r in conn.execute(
-            "SELECT * FROM work_items WHERE status IN ('work','review') ORDER BY updated_at DESC LIMIT 10").fetchall()]
+            f"SELECT * FROM work_items WHERE status IN ('work','review') {ws_and} ORDER BY updated_at DESC LIMIT 10",
+            ws_params).fetchall()]
         recent = [_row_to_dict(r) for r in conn.execute(
-            "SELECT * FROM work_items WHERE status IN ('done','cancelled') ORDER BY updated_at DESC LIMIT 5").fetchall()]
+            f"SELECT * FROM work_items WHERE status IN ('done','cancelled') {ws_and} ORDER BY updated_at DESC LIMIT 5",
+            ws_params).fetchall()]
         blocked = get_blocked_items()
-        next_item = get_next_item()
+        next_item = get_next_item(workspace=workspace)
         # Stale item detection
         now_dt = datetime.now(timezone.utc)
         stale_items = []
         for row in conn.execute(
-            "SELECT * FROM work_items WHERE status IN ('queue','work')"
+            f"SELECT * FROM work_items WHERE status IN ('queue','work') {ws_and}",
+            ws_params,
         ).fetchall():
             item = _row_to_dict(row)
             updated = _parse_dt(item["updated_at"])
@@ -946,18 +973,21 @@ def complete_tree(parent_id: str) -> dict:
 
 # --- Metrics ---
 
-def get_metrics(days: int = 30) -> dict:
+def get_metrics(days: int = 30, workspace: str | None = None) -> dict:
     """Work metrics: throughput, lead time, WIP, stale ratio, breakdowns."""
     conn = get_connection()
     try:
+        ws_clause, ws_params = _workspace_tag_filter(workspace)
+        ws_and = f"AND {ws_clause}" if ws_clause else ""
+
         now_dt = datetime.now(timezone.utc)
         cutoff = (now_dt - timedelta(days=days)).isoformat()
         stale_cutoff = (now_dt - timedelta(days=7)).isoformat()
 
         # Throughput per week (done items in period, grouped by ISO week)
         rows = conn.execute(
-            "SELECT updated_at FROM work_items WHERE status='done' AND updated_at >= ?",
-            (cutoff,),
+            f"SELECT updated_at FROM work_items WHERE status='done' AND updated_at >= ? {ws_and}",
+            [cutoff] + ws_params,
         ).fetchall()
         week_counts: dict[str, int] = {}
         for r in rows:
@@ -969,8 +999,8 @@ def get_metrics(days: int = 30) -> dict:
 
         # Lead time avg (done items in period)
         lt_rows = conn.execute(
-            "SELECT created_at, updated_at FROM work_items WHERE status='done' AND updated_at >= ?",
-            (cutoff,),
+            f"SELECT created_at, updated_at FROM work_items WHERE status='done' AND updated_at >= ? {ws_and}",
+            [cutoff] + ws_params,
         ).fetchall()
         if lt_rows:
             total_secs = sum(
@@ -982,23 +1012,24 @@ def get_metrics(days: int = 30) -> dict:
             lead_time_avg = 0.0
 
         # WIP
-        wip = conn.execute("SELECT COUNT(*) as cnt FROM work_items WHERE status='work'").fetchone()["cnt"]
+        wip = conn.execute(f"SELECT COUNT(*) as cnt FROM work_items WHERE status='work' {ws_and}", ws_params).fetchone()["cnt"]
 
         # Stale ratio
         non_terminal = conn.execute(
-            "SELECT COUNT(*) as cnt FROM work_items WHERE status NOT IN ('done','cancelled')"
+            f"SELECT COUNT(*) as cnt FROM work_items WHERE status NOT IN ('done','cancelled') {ws_and}",
+            ws_params,
         ).fetchone()["cnt"]
         stale = conn.execute(
-            "SELECT COUNT(*) as cnt FROM work_items WHERE status NOT IN ('done','cancelled') AND updated_at < ?",
-            (stale_cutoff,),
+            f"SELECT COUNT(*) as cnt FROM work_items WHERE status NOT IN ('done','cancelled') AND updated_at < ? {ws_and}",
+            [stale_cutoff] + ws_params,
         ).fetchone()["cnt"]
         stale_ratio = (stale / non_terminal * 100) if non_terminal else 0.0
 
         # By priority (done in period)
         by_priority = {"critical": 0, "high": 0, "medium": 0, "low": 0}
         for r in conn.execute(
-            "SELECT priority, COUNT(*) as cnt FROM work_items WHERE status='done' AND updated_at >= ? GROUP BY priority",
-            (cutoff,),
+            f"SELECT priority, COUNT(*) as cnt FROM work_items WHERE status='done' AND updated_at >= ? {ws_and} GROUP BY priority",
+            [cutoff] + ws_params,
         ).fetchall():
             if r["priority"] in by_priority:
                 by_priority[r["priority"]] = r["cnt"]
@@ -1006,7 +1037,8 @@ def get_metrics(days: int = 30) -> dict:
         # By tag (top 10 tags across non-terminal items)
         tag_counts: dict[str, int] = {}
         for r in conn.execute(
-            "SELECT tags FROM work_items WHERE status NOT IN ('done','cancelled') AND tags != ''"
+            f"SELECT tags FROM work_items WHERE status NOT IN ('done','cancelled') AND tags != '' {ws_and}",
+            ws_params,
         ).fetchall():
             for tag in r["tags"].split(","):
                 tag = tag.strip()
@@ -1015,7 +1047,8 @@ def get_metrics(days: int = 30) -> dict:
         by_tag = dict(sorted(tag_counts.items(), key=lambda x: -x[1])[:10])
 
         # Total items
-        total = conn.execute("SELECT COUNT(*) as cnt FROM work_items").fetchone()["cnt"]
+        ws_where = f"WHERE {ws_clause}" if ws_clause else ""
+        total = conn.execute(f"SELECT COUNT(*) as cnt FROM work_items {ws_where}", ws_params).fetchone()["cnt"]
 
         return {
             "throughput_per_week": throughput,

--- a/src/task_orchestrator/prompts.py
+++ b/src/task_orchestrator/prompts.py
@@ -89,8 +89,12 @@ Steps:
     @mcp.prompt()
     def dependency_manager(item_id: str = "") -> str:
         """Visualize, create, and diagnose dependencies between work items."""
-        target = f' for item {item_id}' if item_id else ''
-        query = f'query_dependencies(item_id="{item_id}", neighbors_only=false)' if item_id else 'get_blocked_items()'
+        target = f" for item {item_id}" if item_id else ""
+        query = (
+            f'query_dependencies(item_id="{item_id}", neighbors_only=false)'
+            if item_id
+            else "get_blocked_items()"
+        )
         return f"""Visualize and manage dependencies{target}.
 
 Steps:

--- a/src/task_orchestrator/schemas.py
+++ b/src/task_orchestrator/schemas.py
@@ -107,11 +107,13 @@ def check_gate(item: dict, notes: list[dict], target_role: str) -> dict:
         if note_def["role"] not in roles_to_check:
             continue
         if note_def["key"] not in filled_keys:
-            missing.append({
-                "key": note_def["key"],
-                "role": note_def["role"],
-                "description": note_def.get("description", ""),
-            })
+            missing.append(
+                {
+                    "key": note_def["key"],
+                    "role": note_def["role"],
+                    "description": note_def.get("description", ""),
+                }
+            )
 
     guidance = missing[0]["description"] if missing else None
     return {"can_advance": len(missing) == 0, "missing": missing, "guidance": guidance}

--- a/src/task_orchestrator/server.py
+++ b/src/task_orchestrator/server.py
@@ -36,12 +36,24 @@ def _resolve(id_str: str) -> str:
 
 
 @mcp.tool()
-def manage_items(operation: str, title: str = "", item_id: str = "", description: str = "",
-                 summary: str = "", parent_id: str = "", priority: str = "medium",
-                 complexity: int | None = None, item_type: str = "", tags: str = "",
-                 metadata: str = "", properties: str = "",
-                 due_at: str = "",
-                 items_json: str = "", ids_json: str = "", recursive: bool = False) -> str:
+def manage_items(
+    operation: str,
+    title: str = "",
+    item_id: str = "",
+    description: str = "",
+    summary: str = "",
+    parent_id: str = "",
+    priority: str = "medium",
+    complexity: int | None = None,
+    item_type: str = "",
+    tags: str = "",
+    metadata: str = "",
+    properties: str = "",
+    due_at: str = "",
+    items_json: str = "",
+    ids_json: str = "",
+    recursive: bool = False,
+) -> str:
     """Create, update, or delete work items. Supports batch operations.
 
     Operations: create, update, delete.
@@ -57,13 +69,24 @@ def manage_items(operation: str, title: str = "", item_id: str = "", description
         if operation == "create":
             if items_json:
                 items = json.loads(items_json)
-                return _json(engine.create_items_batch(items, parent_id=parent_id or None))
-            return _json(engine.create_item(
-                title=title, description=description, summary=summary,
-                parent_id=parent_id or None, priority=priority,
-                complexity=complexity, item_type=item_type, tags=tags,
-                metadata=metadata or None, properties=properties or None,
-                due_at=due_at or None))
+                return _json(
+                    engine.create_items_batch(items, parent_id=parent_id or None)
+                )
+            return _json(
+                engine.create_item(
+                    title=title,
+                    description=description,
+                    summary=summary,
+                    parent_id=parent_id or None,
+                    priority=priority,
+                    complexity=complexity,
+                    item_type=item_type,
+                    tags=tags,
+                    metadata=metadata or None,
+                    properties=properties or None,
+                    due_at=due_at or None,
+                )
+            )
         elif operation == "update":
             kwargs = {}
             if title:
@@ -92,16 +115,26 @@ def manage_items(operation: str, title: str = "", item_id: str = "", description
                 ids = json.loads(ids_json)
                 return _json(engine.delete_items_batch(ids, recursive=recursive))
             return _json(engine.delete_item(item_id, recursive=recursive))
-        return _json({"error": f"Invalid operation: {operation}. Use: create, update, delete"})
+        return _json(
+            {"error": f"Invalid operation: {operation}. Use: create, update, delete"}
+        )
     except Exception as e:
         return _err(e)
 
 
 @mcp.tool()
-def query_items(operation: str = "list", item_id: str = "", status: str = "",
-                parent_id: str = "", priority: str = "", search: str = "",
-                tags: str = "",
-                include_ancestors: bool = False, limit: int = 50, offset: int = 0) -> str:
+def query_items(
+    operation: str = "list",
+    item_id: str = "",
+    status: str = "",
+    parent_id: str = "",
+    priority: str = "",
+    search: str = "",
+    tags: str = "",
+    include_ancestors: bool = False,
+    limit: int = 50,
+    offset: int = 0,
+) -> str:
     """Query work items. Operations: get (by id), list (with filters), children (of parent), overview (status counts).
 
     Filters: status (queue/work/review/done/blocked/cancelled), priority, parent_id, search text, tags (comma-separated).
@@ -121,17 +154,32 @@ def query_items(operation: str = "list", item_id: str = "", status: str = "",
             return _json(engine.get_children(parent_id or item_id))
         elif operation == "overview":
             ctx = engine.get_context()
-            return _json({"counts": ctx["counts"], "active_count": len(ctx["active"]),
-                          "blocked_count": len(ctx["blocked"])})
-        return _json(engine.query_items(status=status or None, parent_id=parent_id or None,
-                                        priority=priority or None, search=search or None,
-                                        tags=tags or None, limit=limit, offset=offset))
+            return _json(
+                {
+                    "counts": ctx["counts"],
+                    "active_count": len(ctx["active"]),
+                    "blocked_count": len(ctx["blocked"]),
+                }
+            )
+        return _json(
+            engine.query_items(
+                status=status or None,
+                parent_id=parent_id or None,
+                priority=priority or None,
+                search=search or None,
+                tags=tags or None,
+                limit=limit,
+                offset=offset,
+            )
+        )
     except Exception as e:
         return _err(e)
 
 
 @mcp.tool()
-def advance_item(item_id: str = "", trigger: str = "", transitions_json: str = "") -> str:
+def advance_item(
+    item_id: str = "", trigger: str = "", transitions_json: str = ""
+) -> str:
     """Advance work items through workflow using triggers. Supports batch transitions.
 
     Triggers: start (next phase), complete (jump to done), block/hold (pause), resume (unblock),
@@ -175,7 +223,9 @@ def get_next_item(workspace: str = "") -> str:
 
 
 @mcp.tool()
-def get_context(item_id: str = "", include_ancestors: bool = False, workspace: str = "") -> str:
+def get_context(
+    item_id: str = "", include_ancestors: bool = False, workspace: str = ""
+) -> str:
     """Get context snapshot for session resume or item inspection.
 
     Without item_id: global dashboard — status counts, active items, blocked items, next action.
@@ -185,8 +235,13 @@ def get_context(item_id: str = "", include_ancestors: bool = False, workspace: s
     Call this at session start to understand current work state.
     """
     try:
-        return _json(engine.get_context(_resolve(item_id) or None, include_ancestors=include_ancestors,
-                                        workspace=workspace or None))
+        return _json(
+            engine.get_context(
+                _resolve(item_id) or None,
+                include_ancestors=include_ancestors,
+                workspace=workspace or None,
+            )
+        )
     except Exception as e:
         return _err(e)
 
@@ -201,7 +256,9 @@ def get_blocked_items() -> str:
 
 
 @mcp.tool()
-def manage_notes(operation: str, item_id: str, key: str = "", body: str = "", role: str = "queue") -> str:
+def manage_notes(
+    operation: str, item_id: str, key: str = "", body: str = "", role: str = "queue"
+) -> str:
     """Manage notes on work items. Notes are persistent documentation per phase.
 
     Operations: upsert (create/update by key), delete, list (all notes for item).
@@ -216,7 +273,9 @@ def manage_notes(operation: str, item_id: str, key: str = "", body: str = "", ro
             return _json({"deleted": engine.delete_note(item_id, key)})
         elif operation == "list":
             return _json(engine.get_notes(item_id))
-        return _json({"error": f"Invalid operation: {operation}. Use: upsert, delete, list"})
+        return _json(
+            {"error": f"Invalid operation: {operation}. Use: upsert, delete, list"}
+        )
     except Exception as e:
         return _err(e)
 
@@ -231,10 +290,17 @@ def query_notes(item_id: str, key: str = "", include_body: bool = True) -> str:
         item_id = _resolve(item_id)
         if key:
             from .db import get_connection
+
             conn = get_connection()
             try:
-                row = conn.execute("SELECT * FROM notes WHERE item_id=? AND key=?", (item_id, key)).fetchone()
-                return _json(dict(row) if row else {"error": f"Note '{key}' not found on item {item_id}"})
+                row = conn.execute(
+                    "SELECT * FROM notes WHERE item_id=? AND key=?", (item_id, key)
+                ).fetchone()
+                return _json(
+                    dict(row)
+                    if row
+                    else {"error": f"Note '{key}' not found on item {item_id}"}
+                )
             finally:
                 conn.close()
         return _json(engine.get_notes(item_id, include_body=include_body))
@@ -243,10 +309,16 @@ def query_notes(item_id: str, key: str = "", include_body: bool = True) -> str:
 
 
 @mcp.tool()
-def manage_dependencies(operation: str, from_id: str = "", to_id: str = "",
-                        item_id: str = "", direction: str = "both",
-                        item_ids: str = "", pattern: str = "linear",
-                        unblock_at: str = "done") -> str:
+def manage_dependencies(
+    operation: str,
+    from_id: str = "",
+    to_id: str = "",
+    item_id: str = "",
+    direction: str = "both",
+    item_ids: str = "",
+    pattern: str = "linear",
+    unblock_at: str = "done",
+) -> str:
     """Manage dependency edges between work items.
 
     Operations: add (from_id blocks to_id), remove, query (get deps for item_id), pattern.
@@ -269,14 +341,22 @@ def manage_dependencies(operation: str, from_id: str = "", to_id: str = "",
         elif operation == "pattern":
             ids = [_resolve(i.strip()) for i in item_ids.split(",") if i.strip()]
             return _json(engine.add_dependency_pattern(ids, pattern))
-        return _json({"error": f"Invalid operation: {operation}. Use: add, remove, query, pattern"})
+        return _json(
+            {
+                "error": f"Invalid operation: {operation}. Use: add, remove, query, pattern"
+            }
+        )
     except Exception as e:
         return _err(e)
 
 
 @mcp.tool()
-def query_dependencies(item_id: str, direction: str = "outbound",
-                       neighbors_only: bool = True, max_depth: int = 10) -> str:
+def query_dependencies(
+    item_id: str,
+    direction: str = "outbound",
+    neighbors_only: bool = True,
+    max_depth: int = 10,
+) -> str:
     """Query dependencies with optional BFS traversal.
 
     neighbors_only=true: direct edges only (fast). false: full BFS graph traversal.
@@ -292,9 +372,14 @@ def query_dependencies(item_id: str, direction: str = "outbound",
 
 
 @mcp.tool()
-def create_work_tree(root_title: str, root_description: str = "", root_priority: str = "medium",
-                     children_json: str = "[]", deps_json: str = "[]",
-                     create_notes: bool = False) -> str:
+def create_work_tree(
+    root_title: str,
+    root_description: str = "",
+    root_priority: str = "medium",
+    children_json: str = "[]",
+    deps_json: str = "[]",
+    create_notes: bool = False,
+) -> str:
     """Atomically create a root item + children + dependencies in one call.
 
     children_json: JSON array of {ref, title, description, priority} objects.
@@ -303,12 +388,24 @@ def create_work_tree(root_title: str, root_description: str = "", root_priority:
     Example: children=[{"ref":"a","title":"Schema"},{"ref":"b","title":"API"}], deps=[{"from":"a","to":"b"}]
     """
     try:
-        children = json.loads(children_json) if isinstance(children_json, str) else children_json
+        children = (
+            json.loads(children_json)
+            if isinstance(children_json, str)
+            else children_json
+        )
         deps = json.loads(deps_json) if isinstance(deps_json, str) else deps_json
-        return _json(engine.create_work_tree(
-            root={"title": root_title, "description": root_description, "priority": root_priority},
-            children=children, deps=deps, create_notes=create_notes,
-        ))
+        return _json(
+            engine.create_work_tree(
+                root={
+                    "title": root_title,
+                    "description": root_description,
+                    "priority": root_priority,
+                },
+                children=children,
+                deps=deps,
+                create_notes=create_notes,
+            )
+        )
     except Exception as e:
         return _err(e)
 
@@ -326,7 +423,9 @@ def complete_tree(parent_id: str) -> str:
 
 
 @mcp.tool()
-def manage_schemas(operation: str = "list", schema_name: str = "", item_id: str = "") -> str:
+def manage_schemas(
+    operation: str = "list", schema_name: str = "", item_id: str = ""
+) -> str:
     """View note schemas and check gate status for items.
 
     Operations:
@@ -342,35 +441,62 @@ def manage_schemas(operation: str = "list", schema_name: str = "", item_id: str 
         elif operation == "get":
             schemas = get_schemas()
             if schema_name not in schemas:
-                return _json({"error": f"Schema '{schema_name}' not found", "available": list(schemas.keys())})
+                return _json(
+                    {
+                        "error": f"Schema '{schema_name}' not found",
+                        "available": list(schemas.keys()),
+                    }
+                )
             return _json(schemas[schema_name])
         elif operation == "check":
             item = engine.get_item(item_id)
             if not item:
                 return _json({"error": f"Item {item_id} not found"})
-            schema = get_schema_for_item(item.get("item_type", ""), item.get("tags", ""))
+            schema = get_schema_for_item(
+                item.get("item_type", ""), item.get("tags", "")
+            )
             if not schema:
                 return _json({"has_schema": False, "can_advance": True})
             from .db import get_connection
+
             conn = get_connection()
             try:
-                notes = [dict(r) for r in conn.execute(
-                    "SELECT * FROM notes WHERE item_id=?", (item_id,)).fetchall()]
+                notes = [
+                    dict(r)
+                    for r in conn.execute(
+                        "SELECT * FROM notes WHERE item_id=?", (item_id,)
+                    ).fetchall()
+                ]
             finally:
                 conn.close()
             from .schemas import check_gate
+
             # Check gate for next natural transition
             next_status = engine.TRANSITIONS.get("start", {}).get(item["status"])
             if not next_status:
-                return _json({"has_schema": True, "schema": schema["name"],
-                              "status": item["status"], "can_advance": item["status"] in engine.TERMINAL})
+                return _json(
+                    {
+                        "has_schema": True,
+                        "schema": schema["name"],
+                        "status": item["status"],
+                        "can_advance": item["status"] in engine.TERMINAL,
+                    }
+                )
             gate = check_gate(item, notes, next_status)
-            return _json({"has_schema": True, "schema": schema["name"], "lifecycle": schema["lifecycle"],
-                          **gate})
+            return _json(
+                {
+                    "has_schema": True,
+                    "schema": schema["name"],
+                    "lifecycle": schema["lifecycle"],
+                    **gate,
+                }
+            )
         elif operation == "reload":
             result = load_schemas()
             return _json({"reloaded": True, "schemas": list(result.keys())})
-        return _json({"error": f"Invalid operation: {operation}. Use: list, get, check, reload"})
+        return _json(
+            {"error": f"Invalid operation: {operation}. Use: list, get, check, reload"}
+        )
     except Exception as e:
         return _err(e)
 
@@ -415,6 +541,7 @@ def import_graph(data_json: str, mode: str = "merge") -> str:
     except Exception as e:
         return _err(e)
 
+
 @mcp.tool()
 def get_workspace_context(workspace: str, verbosity: str = "standard") -> str:
     """Get structured context payload for subagents, scoped to a workspace.
@@ -429,7 +556,6 @@ def get_workspace_context(workspace: str, verbosity: str = "standard") -> str:
         return _json(engine.get_workspace_context(workspace, verbosity=verbosity))
     except Exception as e:
         return _err(e)
-
 
 
 @mcp.tool()
@@ -457,27 +583,53 @@ def manage_workspaces(
             return _json(workspace.list_workspaces())
         elif operation == "create":
             tag_list = [t.strip() for t in tags.split(",") if t.strip()]
-            mem_list = [t.strip() for t in memory_tags.split(",") if t.strip()] if memory_tags else []
-            repo_list = [r.strip() for r in repos.split(",") if r.strip()] if repos else None
-            return _json(workspace.create_workspace(
-                name, tag_list, mem_list,
-                repos=repo_list,
-                conventions=conventions or None,
-                description=description or None,
-            ))
+            mem_list = (
+                [t.strip() for t in memory_tags.split(",") if t.strip()]
+                if memory_tags
+                else []
+            )
+            repo_list = (
+                [r.strip() for r in repos.split(",") if r.strip()] if repos else None
+            )
+            return _json(
+                workspace.create_workspace(
+                    name,
+                    tag_list,
+                    mem_list,
+                    repos=repo_list,
+                    conventions=conventions or None,
+                    description=description or None,
+                )
+            )
         elif operation == "update":
-            tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else None
-            mem_list = [t.strip() for t in memory_tags.split(",") if t.strip()] if memory_tags else None
-            repo_list = [r.strip() for r in repos.split(",") if r.strip()] if repos else None
-            return _json(workspace.update_workspace(
-                name, tag_list, mem_list,
-                repos=repo_list,
-                conventions=conventions or None,
-                description=description or None,
-            ))
+            tag_list = (
+                [t.strip() for t in tags.split(",") if t.strip()] if tags else None
+            )
+            mem_list = (
+                [t.strip() for t in memory_tags.split(",") if t.strip()]
+                if memory_tags
+                else None
+            )
+            repo_list = (
+                [r.strip() for r in repos.split(",") if r.strip()] if repos else None
+            )
+            return _json(
+                workspace.update_workspace(
+                    name,
+                    tag_list,
+                    mem_list,
+                    repos=repo_list,
+                    conventions=conventions or None,
+                    description=description or None,
+                )
+            )
         elif operation == "delete":
             return _json(workspace.delete_workspace(name))
-        return _json({"error": f"Invalid operation: {operation}. Use: create, update, delete, list"})
+        return _json(
+            {
+                "error": f"Invalid operation: {operation}. Use: create, update, delete, list"
+            }
+        )
     except Exception as e:
         return _err(e)
 

--- a/src/task_orchestrator/server.py
+++ b/src/task_orchestrator/server.py
@@ -415,14 +415,41 @@ def import_graph(data_json: str, mode: str = "merge") -> str:
     except Exception as e:
         return _err(e)
 
+@mcp.tool()
+def get_workspace_context(workspace: str, verbosity: str = "standard") -> str:
+    """Get structured context payload for subagents, scoped to a workspace.
+
+    Returns workspace brief, status counts, active/blocked items, and next action.
+    Verbosity levels control token budget:
+    - minimal: workspace + status_counts + next_item + memory_tags (~200 tokens)
+    - standard: + active_items + blocked_items (~1000 tokens)
+    - full: + recent_decisions (~2000 tokens)
+    """
+    try:
+        return _json(engine.get_workspace_context(workspace, verbosity=verbosity))
+    except Exception as e:
+        return _err(e)
+
+
 
 @mcp.tool()
-def manage_workspaces(operation: str, name: str = "", tags: str = "", memory_tags: str = "") -> str:
+def manage_workspaces(
+    operation: str,
+    name: str = "",
+    tags: str = "",
+    memory_tags: str = "",
+    repos: str = "",
+    conventions: str = "",
+    description: str = "",
+) -> str:
     """Manage workspace configurations. Workspaces map tag groups for scoped queries.
 
     Operations: create, update, delete, list.
     tags: comma-separated list of item tags that belong to this workspace.
-    memory_tags: comma-separated list of memory service tags for this workspace.
+    memory_tags: comma-separated list of tags to search in external memory service (mcp-memory-service).
+    repos: comma-separated list of repo paths associated with this workspace.
+    conventions: free-text coding conventions for this workspace.
+    description: workspace description (used as brief in get_workspace_context).
     Use workspace param in get_context, get_next_item, get_metrics to filter by workspace.
     """
     try:
@@ -431,11 +458,23 @@ def manage_workspaces(operation: str, name: str = "", tags: str = "", memory_tag
         elif operation == "create":
             tag_list = [t.strip() for t in tags.split(",") if t.strip()]
             mem_list = [t.strip() for t in memory_tags.split(",") if t.strip()] if memory_tags else []
-            return _json(workspace.create_workspace(name, tag_list, mem_list))
+            repo_list = [r.strip() for r in repos.split(",") if r.strip()] if repos else None
+            return _json(workspace.create_workspace(
+                name, tag_list, mem_list,
+                repos=repo_list,
+                conventions=conventions or None,
+                description=description or None,
+            ))
         elif operation == "update":
             tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else None
             mem_list = [t.strip() for t in memory_tags.split(",") if t.strip()] if memory_tags else None
-            return _json(workspace.update_workspace(name, tag_list, mem_list))
+            repo_list = [r.strip() for r in repos.split(",") if r.strip()] if repos else None
+            return _json(workspace.update_workspace(
+                name, tag_list, mem_list,
+                repos=repo_list,
+                conventions=conventions or None,
+                description=description or None,
+            ))
         elif operation == "delete":
             return _json(workspace.delete_workspace(name))
         return _json({"error": f"Invalid operation: {operation}. Use: create, update, delete, list"})

--- a/src/task_orchestrator/server.py
+++ b/src/task_orchestrator/server.py
@@ -6,6 +6,7 @@ from . import db, engine
 from .engine import ToolError
 from .schemas import get_schemas, load_schemas, get_schema_for_item
 from .prompts import register_prompts
+from . import workspace
 
 mcp = FastMCP(
     "task-orchestrator",
@@ -162,27 +163,30 @@ def get_next_status(item_id: str, trigger: str) -> str:
 
 
 @mcp.tool()
-def get_next_item() -> str:
+def get_next_item(workspace: str = "") -> str:
     """Get the highest-priority actionable item with no unsatisfied dependencies.
 
     Returns the single best next item to work on, or null if nothing is actionable.
     Priority: items already in 'work' first, then by priority (critical > high > medium > low).
+    Use workspace to filter by workspace tags (e.g. workspace="dtp").
     """
-    result = engine.get_next_item()
+    result = engine.get_next_item(workspace=workspace or None)
     return _json(result) if result else _json({"message": "No actionable items"})
 
 
 @mcp.tool()
-def get_context(item_id: str = "", include_ancestors: bool = False) -> str:
+def get_context(item_id: str = "", include_ancestors: bool = False, workspace: str = "") -> str:
     """Get context snapshot for session resume or item inspection.
 
     Without item_id: global dashboard — status counts, active items, blocked items, next action.
     With item_id: item detail — children, notes, blockers, can_advance flag.
     Use include_ancestors=true to get the full parent chain.
+    Use workspace to filter by workspace tags (e.g. workspace="dtp").
     Call this at session start to understand current work state.
     """
     try:
-        return _json(engine.get_context(_resolve(item_id) or None, include_ancestors=include_ancestors))
+        return _json(engine.get_context(_resolve(item_id) or None, include_ancestors=include_ancestors,
+                                        workspace=workspace or None))
     except Exception as e:
         return _err(e)
 
@@ -372,13 +376,14 @@ def manage_schemas(operation: str = "list", schema_name: str = "", item_id: str 
 
 
 @mcp.tool()
-def get_metrics(days: int = 30) -> str:
+def get_metrics(days: int = 30, workspace: str = "") -> str:
     """Work metrics — throughput per week, average lead time, WIP count, stale ratio, breakdowns by priority and tag.
 
     Optional days param controls the lookback period (default: 30).
+    Use workspace to filter by workspace tags (e.g. workspace="dtp").
     """
     try:
-        return _json(engine.get_metrics(days=days))
+        return _json(engine.get_metrics(days=days, workspace=workspace or None))
     except Exception as e:
         return _err(e)
 
@@ -407,6 +412,33 @@ def import_graph(data_json: str, mode: str = "merge") -> str:
     try:
         data = json.loads(data_json)
         return _json(engine.import_graph(data, mode=mode))
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def manage_workspaces(operation: str, name: str = "", tags: str = "", memory_tags: str = "") -> str:
+    """Manage workspace configurations. Workspaces map tag groups for scoped queries.
+
+    Operations: create, update, delete, list.
+    tags: comma-separated list of item tags that belong to this workspace.
+    memory_tags: comma-separated list of memory service tags for this workspace.
+    Use workspace param in get_context, get_next_item, get_metrics to filter by workspace.
+    """
+    try:
+        if operation == "list":
+            return _json(workspace.list_workspaces())
+        elif operation == "create":
+            tag_list = [t.strip() for t in tags.split(",") if t.strip()]
+            mem_list = [t.strip() for t in memory_tags.split(",") if t.strip()] if memory_tags else []
+            return _json(workspace.create_workspace(name, tag_list, mem_list))
+        elif operation == "update":
+            tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else None
+            mem_list = [t.strip() for t in memory_tags.split(",") if t.strip()] if memory_tags else None
+            return _json(workspace.update_workspace(name, tag_list, mem_list))
+        elif operation == "delete":
+            return _json(workspace.delete_workspace(name))
+        return _json({"error": f"Invalid operation: {operation}. Use: create, update, delete, list"})
     except Exception as e:
         return _err(e)
 

--- a/src/task_orchestrator/workspace.py
+++ b/src/task_orchestrator/workspace.py
@@ -1,0 +1,70 @@
+"""Workspace management — tag-group config with JSON file storage."""
+
+import json
+import os
+from pathlib import Path
+
+from .db import DB_PATH
+
+
+def _config_path() -> str:
+    return os.environ.get(
+        "TASK_ORCHESTRATOR_WORKSPACES",
+        str(Path(DB_PATH).parent / "workspaces.json"),
+    )
+
+
+def _load() -> dict:
+    path = _config_path()
+    if not os.path.exists(path):
+        return {}
+    with open(path) as f:
+        return json.load(f)
+
+
+def _save(data: dict):
+    path = _config_path()
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def list_workspaces() -> dict:
+    return _load()
+
+
+def create_workspace(name: str, tags: list[str], memory_tags: list[str] | None = None) -> dict:
+    data = _load()
+    if name in data:
+        raise ValueError(f"Workspace '{name}' already exists")
+    data[name] = {"tags": tags, "memory_tags": memory_tags or []}
+    _save(data)
+    return {name: data[name]}
+
+
+def update_workspace(name: str, tags: list[str] | None = None, memory_tags: list[str] | None = None) -> dict:
+    data = _load()
+    if name not in data:
+        raise ValueError(f"Workspace '{name}' not found")
+    if tags is not None:
+        data[name]["tags"] = tags
+    if memory_tags is not None:
+        data[name]["memory_tags"] = memory_tags
+    _save(data)
+    return {name: data[name]}
+
+
+def delete_workspace(name: str) -> dict:
+    data = _load()
+    if name not in data:
+        raise ValueError(f"Workspace '{name}' not found")
+    del data[name]
+    _save(data)
+    return {"deleted": name}
+
+
+def get_workspace_tags(name: str) -> list[str] | None:
+    """Get tags for a workspace. Returns None if workspace not found."""
+    data = _load()
+    ws = data.get(name)
+    return ws["tags"] if ws else None

--- a/src/task_orchestrator/workspace.py
+++ b/src/task_orchestrator/workspace.py
@@ -6,6 +6,9 @@ from pathlib import Path
 
 from .db import DB_PATH
 
+# Valid workspace config fields (beyond required 'tags')
+OPTIONAL_FIELDS = ("memory_tags", "repos", "conventions", "description")
+
 
 def _config_path() -> str:
     return os.environ.get(
@@ -33,16 +36,37 @@ def list_workspaces() -> dict:
     return _load()
 
 
-def create_workspace(name: str, tags: list[str], memory_tags: list[str] | None = None) -> dict:
+def create_workspace(
+    name: str,
+    tags: list[str],
+    memory_tags: list[str] | None = None,
+    repos: list[str] | None = None,
+    conventions: str | None = None,
+    description: str | None = None,
+) -> dict:
     data = _load()
     if name in data:
         raise ValueError(f"Workspace '{name}' already exists")
-    data[name] = {"tags": tags, "memory_tags": memory_tags or []}
+    ws = {"tags": tags, "memory_tags": memory_tags or []}
+    if repos:
+        ws["repos"] = repos
+    if conventions:
+        ws["conventions"] = conventions
+    if description:
+        ws["description"] = description
+    data[name] = ws
     _save(data)
     return {name: data[name]}
 
 
-def update_workspace(name: str, tags: list[str] | None = None, memory_tags: list[str] | None = None) -> dict:
+def update_workspace(
+    name: str,
+    tags: list[str] | None = None,
+    memory_tags: list[str] | None = None,
+    repos: list[str] | None = None,
+    conventions: str | None = None,
+    description: str | None = None,
+) -> dict:
     data = _load()
     if name not in data:
         raise ValueError(f"Workspace '{name}' not found")
@@ -50,6 +74,12 @@ def update_workspace(name: str, tags: list[str] | None = None, memory_tags: list
         data[name]["tags"] = tags
     if memory_tags is not None:
         data[name]["memory_tags"] = memory_tags
+    if repos is not None:
+        data[name]["repos"] = repos
+    if conventions is not None:
+        data[name]["conventions"] = conventions
+    if description is not None:
+        data[name]["description"] = description
     _save(data)
     return {name: data[name]}
 
@@ -68,3 +98,9 @@ def get_workspace_tags(name: str) -> list[str] | None:
     data = _load()
     ws = data.get(name)
     return ws["tags"] if ws else None
+
+
+def get_workspace_context(name: str) -> dict | None:
+    """Get full workspace config for context injection. Returns None if not found."""
+    data = _load()
+    return data.get(name)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -10,11 +10,13 @@ from task_orchestrator.engine import ToolError
 
 # --- Helpers ---
 
+
 def _create(title="Test Item", **kw):
     return engine.create_item(title=title, **kw)
 
 
 # --- CRUD ---
+
 
 def test_create_item():
     item = _create("My Task", description="desc", priority="high")
@@ -46,7 +48,9 @@ def test_create_item_max_depth():
 
 def test_update_item():
     item = _create("Original")
-    updated = engine.update_item(item["id"], title="Updated", description="new desc", priority="critical")
+    updated = engine.update_item(
+        item["id"], title="Updated", description="new desc", priority="critical"
+    )
     assert updated["title"] == "Updated"
     assert updated["description"] == "new desc"
     assert updated["priority"] == "critical"
@@ -70,6 +74,7 @@ def test_delete_item_recursive():
 
 
 # --- Query ---
+
 
 def test_query_items_by_status():
     a = _create("A")
@@ -105,6 +110,7 @@ def test_query_items_search():
 
 
 # --- Workflow ---
+
 
 def test_advance_item_workflow():
     item = _create("Flow")
@@ -142,10 +148,12 @@ def test_advance_item_cancel_reopen():
 def test_batch_transitions():
     a = _create("A")
     b = _create("B")
-    result = engine.advance_items_batch([
-        {"item_id": a["id"], "trigger": "start"},
-        {"item_id": b["id"], "trigger": "complete"},
-    ])
+    result = engine.advance_items_batch(
+        [
+            {"item_id": a["id"], "trigger": "start"},
+            {"item_id": b["id"], "trigger": "complete"},
+        ]
+    )
     assert result["summary"]["succeeded"] == 2
     assert result["summary"]["failed"] == 0
     assert result["results"][0]["new_status"] == "work"
@@ -153,6 +161,7 @@ def test_batch_transitions():
 
 
 # --- Dependencies ---
+
 
 def test_dependencies_add_query():
     a = _create("A")
@@ -208,6 +217,7 @@ def test_dependencies_unblock_at():
 
 # --- Notes ---
 
+
 def test_notes_upsert_query():
     item = _create("Noted")
     note = engine.upsert_note(item["id"], "requirements", "Must do X", role="queue")
@@ -226,6 +236,7 @@ def test_notes_delete():
 
 
 # --- Work Tree ---
+
 
 def test_create_work_tree():
     result = engine.create_work_tree(
@@ -255,6 +266,7 @@ def test_complete_tree():
 
 # --- Context ---
 
+
 def test_get_context_global():
     _create("A")
     _create("B")
@@ -279,6 +291,7 @@ def test_get_context_item():
 
 # --- Next Item / Blocked ---
 
+
 def test_get_next_item():
     _create("Low", priority="low")
     _create("Critical", priority="critical")
@@ -297,6 +310,7 @@ def test_get_blocked_items():
 
 
 # --- Short Hex ID ---
+
 
 def test_short_hex_id():
     item = _create("Resolvable")
@@ -320,6 +334,7 @@ def test_short_hex_id_not_found():
 
 # --- ToolError ---
 
+
 def test_tool_error():
     err = ToolError("VALIDATION", "bad input", field="title")
     assert err.code == "VALIDATION"
@@ -333,13 +348,16 @@ def test_tool_error():
 
 # --- Stale Detection ---
 
+
 def test_stale_detection():
     item = _create("Old Item")
     # Manually backdate updated_at to 10 days ago
     conn = db.get_connection()
     try:
         old_date = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
-        conn.execute("UPDATE work_items SET updated_at=? WHERE id=?", (old_date, item["id"]))
+        conn.execute(
+            "UPDATE work_items SET updated_at=? WHERE id=?", (old_date, item["id"])
+        )
         conn.commit()
     finally:
         conn.close()
@@ -349,6 +367,7 @@ def test_stale_detection():
 
 
 # --- Additional edge cases ---
+
 
 def test_delete_item_with_children_no_recursive():
     parent = _create("Parent")
@@ -389,6 +408,7 @@ def test_notes_upsert_update():
 
 # --- Due Dates ---
 
+
 def test_create_item_with_due_date():
     due = (datetime.now(timezone.utc) + timedelta(hours=5)).isoformat()
     item = _create("Due Soon", due_at=due)
@@ -412,6 +432,7 @@ def test_overdue_detection():
 
 
 # --- Export / Import ---
+
 
 def test_export_graph():
     a = _create("A")
@@ -464,8 +485,8 @@ def test_import_replace():
     assert result["counts"]["items"] == 2
 
 
-
 # --- FTS Search ---
+
 
 def test_fts_search_description():
     """FTS5 finds items by description content."""
@@ -492,8 +513,8 @@ def test_fts_search_partial():
     assert "authentication" in items[0]["title"]
 
 
-
 # --- Scheduled Items ---
+
 
 def test_scheduled_item_create():
     item = _create("Daily Standup", schedule="0 9 * * *")
@@ -540,6 +561,7 @@ def test_invalid_cron_expression():
 
 # --- Metrics ---
 
+
 def test_metrics_basic():
     """Create items in various states, verify metric counts."""
     # done items
@@ -554,7 +576,9 @@ def test_metrics_basic():
     conn = db.get_connection()
     try:
         old = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
-        conn.execute("UPDATE work_items SET updated_at=? WHERE id=?", (old, stale["id"]))
+        conn.execute(
+            "UPDATE work_items SET updated_at=? WHERE id=?", (old, stale["id"])
+        )
         conn.commit()
     finally:
         conn.close()
@@ -598,13 +622,16 @@ def test_metrics_throughput():
 
 # --- _parse_dt helper ---
 
+
 def test_parse_dt_aware():
     dt = engine._parse_dt("2026-05-03T12:00:00+00:00")
     assert dt.tzinfo is not None
 
+
 def test_parse_dt_naive_assumes_utc():
     dt = engine._parse_dt("2026-05-03 12:00:00")
     assert dt.tzinfo == timezone.utc
+
 
 def test_get_context_with_naive_timestamps():
     """get_context should not crash when items have naive datetime strings."""
@@ -620,6 +647,7 @@ def test_get_context_with_naive_timestamps():
     # Should not raise "can't subtract offset-naive and offset-aware datetimes"
     ctx = engine.get_context()
     assert "counts" in ctx
+
 
 def test_get_metrics_with_naive_timestamps():
     """get_metrics should not crash when done items have naive datetime strings."""

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -57,7 +57,8 @@ class TestWorkspaceCRUD:
 class TestWorkspaceExtendedFields:
     def test_create_with_all_fields(self):
         workspace.create_workspace(
-            "dtp", ["mir", "rer"],
+            "dtp",
+            ["mir", "rer"],
             memory_tags=["mir", "dtp"],
             repos=["~/git/mir"],
             conventions="Python 3.11+, pytest",
@@ -89,7 +90,8 @@ class TestWorkspaceExtendedFields:
 
     def test_get_workspace_context(self):
         workspace.create_workspace(
-            "dtp", ["mir"],
+            "dtp",
+            ["mir"],
             memory_tags=["mir"],
             description="Work",
         )
@@ -162,8 +164,12 @@ class TestScopedQueries:
 
 class TestGetWorkspaceContext:
     def _setup(self):
-        workspace.create_workspace("mir", ["mir", "roma"], memory_tags=["mir", "spring-boot"],
-                                   description="MIR - Sistema gov.br")
+        workspace.create_workspace(
+            "mir",
+            ["mir", "roma"],
+            memory_tags=["mir", "spring-boot"],
+            description="MIR - Sistema gov.br",
+        )
         engine.create_item(title="API endpoint", tags="mir", priority="high")
         engine.create_item(title="DB migration", tags="roma", priority="medium")
         engine.create_item(title="Unrelated", tags="other")
@@ -222,6 +228,7 @@ class TestGetWorkspaceContext:
 
     def test_output_is_json_serializable(self):
         import json
+
         self._setup()
         ctx = engine.get_workspace_context("mir", verbosity="full")
         # Should not raise

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -54,6 +54,55 @@ class TestWorkspaceCRUD:
         assert workspace.get_workspace_tags("nope") is None
 
 
+class TestWorkspaceExtendedFields:
+    def test_create_with_all_fields(self):
+        workspace.create_workspace(
+            "dtp", ["mir", "rer"],
+            memory_tags=["mir", "dtp"],
+            repos=["~/git/mir"],
+            conventions="Python 3.11+, pytest",
+            description="Work projects",
+        )
+        result = workspace.list_workspaces()
+        assert result["dtp"]["repos"] == ["~/git/mir"]
+        assert result["dtp"]["conventions"] == "Python 3.11+, pytest"
+        assert result["dtp"]["description"] == "Work projects"
+
+    def test_create_minimal_omits_optional(self):
+        workspace.create_workspace("minimal", ["tag1"])
+        result = workspace.list_workspaces()
+        assert "repos" not in result["minimal"]
+        assert "conventions" not in result["minimal"]
+        assert "description" not in result["minimal"]
+
+    def test_update_description(self):
+        workspace.create_workspace("dtp", ["mir"])
+        workspace.update_workspace("dtp", description="Updated")
+        result = workspace.list_workspaces()
+        assert result["dtp"]["description"] == "Updated"
+
+    def test_update_repos(self):
+        workspace.create_workspace("dtp", ["mir"])
+        workspace.update_workspace("dtp", repos=["~/git/a", "~/git/b"])
+        result = workspace.list_workspaces()
+        assert result["dtp"]["repos"] == ["~/git/a", "~/git/b"]
+
+    def test_get_workspace_context(self):
+        workspace.create_workspace(
+            "dtp", ["mir"],
+            memory_tags=["mir"],
+            description="Work",
+        )
+        ctx = workspace.get_workspace_context("dtp")
+        assert ctx is not None
+        assert ctx["tags"] == ["mir"]
+        assert ctx["memory_tags"] == ["mir"]
+        assert ctx["description"] == "Work"
+
+    def test_get_workspace_context_not_found(self):
+        assert workspace.get_workspace_context("nope") is None
+
+
 class TestScopedQueries:
     def _create_items(self):
         """Create items in different workspaces."""
@@ -109,3 +158,72 @@ class TestScopedQueries:
     def test_get_metrics_workspace_not_found(self):
         with pytest.raises(engine.ToolError, match="not found"):
             engine.get_metrics(workspace="nonexistent")
+
+
+class TestGetWorkspaceContext:
+    def _setup(self):
+        workspace.create_workspace("mir", ["mir", "roma"], memory_tags=["mir", "spring-boot"],
+                                   description="MIR - Sistema gov.br")
+        engine.create_item(title="API endpoint", tags="mir", priority="high")
+        engine.create_item(title="DB migration", tags="roma", priority="medium")
+        engine.create_item(title="Unrelated", tags="other")
+
+    def test_minimal_verbosity(self):
+        self._setup()
+        ctx = engine.get_workspace_context("mir", verbosity="minimal")
+        assert ctx["workspace"] == "mir"
+        assert ctx["brief"] == "MIR - Sistema gov.br"
+        assert ctx["status_counts"]["queue"] == 2
+        assert ctx["memory_tags"] == ["mir", "spring-boot"]
+        assert ctx["next_item"] is not None
+        assert "active_items" not in ctx
+        assert "blocked_items" not in ctx
+        assert "recent_decisions" not in ctx
+
+    def test_standard_verbosity(self):
+        self._setup()
+        # Move one item to work
+        items = engine.query_items(tags="mir")
+        engine.advance_item(items[0]["id"], "start")
+        ctx = engine.get_workspace_context("mir", verbosity="standard")
+        assert "active_items" in ctx
+        assert "blocked_items" in ctx
+        assert "recent_decisions" not in ctx
+        assert len(ctx["active_items"]) == 1
+        assert ctx["active_items"][0]["status"] == "work"
+
+    def test_full_verbosity_with_decisions(self):
+        self._setup()
+        items = engine.query_items(tags="mir")
+        engine.advance_item(items[0]["id"], "start")
+        engine.upsert_note(items[0]["id"], "decision-arch", "Use REST", role="review")
+        ctx = engine.get_workspace_context("mir", verbosity="full")
+        assert "recent_decisions" in ctx
+        assert len(ctx["recent_decisions"]) == 1
+        assert ctx["recent_decisions"][0]["key"] == "decision-arch"
+
+    def test_workspace_not_found_raises(self):
+        with pytest.raises(engine.ToolError, match="not found"):
+            engine.get_workspace_context("nonexistent")
+
+    def test_invalid_verbosity_raises(self):
+        workspace.create_workspace("x", ["x"])
+        with pytest.raises(engine.ToolError, match="Invalid verbosity"):
+            engine.get_workspace_context("x", verbosity="invalid")
+
+    def test_blocked_items_included_in_standard(self):
+        workspace.create_workspace("mir", ["mir"], description="MIR")
+        item1 = engine.create_item(title="Blocker", tags="mir")
+        item2 = engine.create_item(title="Blocked", tags="mir")
+        engine.add_dependency(item1["id"], item2["id"])
+        ctx = engine.get_workspace_context("mir", verbosity="standard")
+        blocked_ids = [b["id"] for b in ctx["blocked_items"]]
+        assert item2["id"] in blocked_ids
+
+    def test_output_is_json_serializable(self):
+        import json
+        self._setup()
+        ctx = engine.get_workspace_context("mir", verbosity="full")
+        # Should not raise
+        serialized = json.dumps(ctx, default=str)
+        assert len(serialized) > 0

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -3,7 +3,6 @@
 import json
 import pytest
 
-from task_orchestrator import db
 from task_orchestrator import engine
 from task_orchestrator import workspace
 
@@ -227,7 +226,6 @@ class TestGetWorkspaceContext:
         assert item2["id"] in blocked_ids
 
     def test_output_is_json_serializable(self):
-        import json
 
         self._setup()
         ctx = engine.get_workspace_context("mir", verbosity="full")

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,0 +1,111 @@
+"""Tests for workspace entity and scoped queries."""
+
+import json
+import pytest
+
+from task_orchestrator import db
+from task_orchestrator import engine
+from task_orchestrator import workspace
+
+
+@pytest.fixture(autouse=True)
+def workspace_config(tmp_db, tmp_path, monkeypatch):
+    """Point workspace config to temp dir."""
+    ws_path = str(tmp_path / "workspaces.json")
+    monkeypatch.setenv("TASK_ORCHESTRATOR_WORKSPACES", ws_path)
+    return ws_path
+
+
+class TestWorkspaceCRUD:
+    def test_create_and_list(self):
+        workspace.create_workspace("dtp", ["mir", "rer"], ["mir"])
+        result = workspace.list_workspaces()
+        assert "dtp" in result
+        assert result["dtp"]["tags"] == ["mir", "rer"]
+        assert result["dtp"]["memory_tags"] == ["mir"]
+
+    def test_create_duplicate_raises(self):
+        workspace.create_workspace("dtp", ["mir"])
+        with pytest.raises(ValueError, match="already exists"):
+            workspace.create_workspace("dtp", ["rer"])
+
+    def test_update(self):
+        workspace.create_workspace("dtp", ["mir"])
+        workspace.update_workspace("dtp", tags=["mir", "rer"])
+        result = workspace.list_workspaces()
+        assert result["dtp"]["tags"] == ["mir", "rer"]
+
+    def test_update_nonexistent_raises(self):
+        with pytest.raises(ValueError, match="not found"):
+            workspace.update_workspace("nope", tags=["x"])
+
+    def test_delete(self):
+        workspace.create_workspace("dtp", ["mir"])
+        workspace.delete_workspace("dtp")
+        assert workspace.list_workspaces() == {}
+
+    def test_delete_nonexistent_raises(self):
+        with pytest.raises(ValueError, match="not found"):
+            workspace.delete_workspace("nope")
+
+    def test_get_workspace_tags(self):
+        workspace.create_workspace("dtp", ["mir", "rer"])
+        assert workspace.get_workspace_tags("dtp") == ["mir", "rer"]
+        assert workspace.get_workspace_tags("nope") is None
+
+
+class TestScopedQueries:
+    def _create_items(self):
+        """Create items in different workspaces."""
+        workspace.create_workspace("dtp", ["mir", "rer"])
+        workspace.create_workspace("pessoal", ["papo-saude"])
+
+        engine.create_item(title="MIR task", tags="mir")
+        engine.create_item(title="RER task", tags="rer")
+        engine.create_item(title="Personal task", tags="papo-saude")
+        engine.create_item(title="Untagged task")
+
+    def test_get_context_no_workspace_returns_all(self):
+        self._create_items()
+        ctx = engine.get_context()
+        assert ctx["counts"]["queue"] == 4
+
+    def test_get_context_with_workspace_filters(self):
+        self._create_items()
+        ctx = engine.get_context(workspace="dtp")
+        assert ctx["counts"]["queue"] == 2
+
+    def test_get_context_workspace_not_found(self):
+        with pytest.raises(engine.ToolError, match="not found"):
+            engine.get_context(workspace="nonexistent")
+
+    def test_get_next_item_no_workspace(self):
+        self._create_items()
+        item = engine.get_next_item()
+        assert item is not None
+
+    def test_get_next_item_with_workspace(self):
+        self._create_items()
+        item = engine.get_next_item(workspace="pessoal")
+        assert item is not None
+        assert "papo-saude" in item["tags"]
+
+    def test_get_next_item_workspace_empty(self):
+        workspace.create_workspace("empty", ["no-such-tag"])
+        engine.create_item(title="Some task", tags="other")
+        item = engine.get_next_item(workspace="empty")
+        assert item is None
+
+    def test_get_metrics_no_workspace(self):
+        self._create_items()
+        metrics = engine.get_metrics()
+        assert metrics["total_items"] == 4
+
+    def test_get_metrics_with_workspace(self):
+        self._create_items()
+        metrics = engine.get_metrics(workspace="dtp")
+        assert metrics["total_items"] == 2
+
+    def test_get_metrics_workspace_not_found(self):
+        with pytest.raises(engine.ToolError, match="not found"):
+            engine.get_metrics(workspace="nonexistent")


### PR DESCRIPTION
Enhances workspace config with memory_tags, repos, conventions, description fields. Adds docs/WORKSPACE-GUIDE.md documenting the 2-level context pattern (inline orchestrator data + on-demand memory service references).

## Changes
- `workspace.py`: added `repos`, `conventions`, `description` fields + `get_workspace_context()`
- `server.py`: updated `manage_workspaces` tool with new parameters
- `docs/WORKSPACE-GUIDE.md`: full guide with examples (dtp, pessoal, infra)
- `tests/test_workspace.py`: 7 new test cases for extended fields

Closes #27