### PR TITLE
feat: Kanban Web UI (#29)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,17 @@ Repository = "https://github.com/filhocf/task-orchestrator-py"
 
 [project.scripts]
 task-orchestrator-py = "task_orchestrator.server:main"
+task-orchestrator-ui = "task_orchestrator.ui.app:main"
 
 [project.optional-dependencies]
 test = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
+]
+ui = [
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.30.0",
+    "jinja2>=3.1.0",
 ]
 
 [build-system]

--- a/src/task_orchestrator/ui/__init__.py
+++ b/src/task_orchestrator/ui/__init__.py
@@ -1,0 +1,1 @@
+"""Kanban Web UI for task-orchestrator."""

--- a/src/task_orchestrator/ui/app.py
+++ b/src/task_orchestrator/ui/app.py
@@ -1,0 +1,181 @@
+"""FastAPI Kanban Web UI for task-orchestrator."""
+
+import argparse
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fastapi import FastAPI, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+
+from ..engine import advance_item, query_items, ToolError
+from ..workspace import list_workspaces
+
+app = FastAPI(title="Task Orchestrator Kanban")
+templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
+
+STATUSES = ["queue", "work", "review", "done"]
+PRIORITY_EMOJI = {
+    "critical": "🔴",
+    "high": "🟠",
+    "medium": "🔵",
+    "low": "⚪",
+}
+STATUS_TRIGGERS = {
+    "queue": None,
+    "work": "start",
+    "review": "start",
+    "done": "start",
+}
+
+
+def _age_days(created_at: str) -> int:
+    try:
+        dt = datetime.fromisoformat(created_at)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return (datetime.now(timezone.utc) - dt).days
+    except (ValueError, TypeError):
+        return 0
+
+
+def _trigger_for_move(from_status: str, to_status: str) -> str | None:
+    """Determine the trigger needed to move from one status to another."""
+    if to_status == "done" and from_status in ("queue", "work", "review"):
+        return "complete"
+    if to_status == "queue" and from_status in ("done", "cancelled"):
+        return "reopen"
+    order = {"queue": 0, "work": 1, "review": 2, "done": 3}
+    if order.get(to_status, -1) > order.get(from_status, -1):
+        return "start"
+    return None
+
+
+def _get_board_data(workspace: str | None) -> dict:
+    """Get items grouped by status for a workspace."""
+    columns = {}
+    for status in STATUSES:
+        if workspace:
+            ws_config = list_workspaces().get(workspace)
+            if ws_config:
+                tags = ",".join(ws_config["tags"])
+                items = query_items(status=status, tags=tags, limit=200)
+            else:
+                items = query_items(status=status, limit=200)
+        else:
+            items = query_items(status=status, limit=200)
+        for item in items:
+            item["age"] = _age_days(item.get("created_at", ""))
+            item["priority_emoji"] = PRIORITY_EMOJI.get(item.get("priority", ""), "⚪")
+        columns[status] = items
+    return columns
+
+
+@app.get("/", response_class=RedirectResponse)
+def index():
+    workspaces = list_workspaces()
+    if workspaces:
+        first = next(iter(workspaces))
+        return RedirectResponse(url=f"/board/{first}", status_code=302)
+    return RedirectResponse(url="/board/_all", status_code=302)
+
+
+@app.get("/board/{workspace}", response_class=HTMLResponse)
+def board(request: Request, workspace: str):
+    ws = None if workspace == "_all" else workspace
+    columns = _get_board_data(ws)
+    workspaces = list_workspaces()
+    return templates.TemplateResponse(
+        request,
+        "board.html",
+        {
+            "workspace": workspace,
+            "workspaces": workspaces,
+            "columns": columns,
+            "statuses": STATUSES,
+            "priority_emoji": PRIORITY_EMOJI,
+        },
+    )
+
+
+@app.get("/board/{workspace}/column/{status}", response_class=HTMLResponse)
+def column_partial(request: Request, workspace: str, status: str):
+    ws = None if workspace == "_all" else workspace
+    columns = _get_board_data(ws)
+    items = columns.get(status, [])
+    return templates.TemplateResponse(
+        request,
+        "partials/column.html",
+        {"status": status, "items": items, "workspace": workspace},
+    )
+
+
+@app.post("/board/move", response_class=HTMLResponse)
+def move_item(
+    request: Request,
+    item_id: str = Form(...),
+    new_status: str = Form(...),
+    workspace: str = Form("_all"),
+):
+    # Determine current status
+    items = query_items(limit=500)
+    current_status = None
+    for item in items:
+        if item["id"] == item_id:
+            current_status = item["status"]
+            break
+
+    error = None
+    if current_status and current_status != new_status:
+        trigger = _trigger_for_move(current_status, new_status)
+        if trigger:
+            try:
+                advance_item(item_id, trigger)
+            except ToolError as e:
+                error = e.message
+            except Exception as e:
+                error = str(e)
+
+    # Return updated columns for both source and target
+    ws = None if workspace == "_all" else workspace
+    columns = _get_board_data(ws)
+
+    parts = []
+    for status in STATUSES:
+        html = templates.TemplateResponse(
+            request,
+            "partials/column.html",
+            {
+                "status": status,
+                "items": columns.get(status, []),
+                "workspace": workspace,
+                "error": error if status == new_status else None,
+            },
+        )
+        parts.append(html.body.decode())
+    return HTMLResponse("".join(parts))
+
+
+@app.get("/workspaces")
+def get_workspaces():
+    return list_workspaces()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Task Orchestrator Kanban UI")
+    parser.add_argument("--port", type=int, default=8080, help="Port (default: 8080)")
+    parser.add_argument("--host", default="127.0.0.1", help="Host (default: 127.0.0.1)")
+    parser.add_argument("--db", help="Database path (overrides TASK_ORCHESTRATOR_DB)")
+    args = parser.parse_args()
+
+    if args.db:
+        os.environ["TASK_ORCHESTRATOR_DB"] = args.db
+
+    import uvicorn
+
+    uvicorn.run(app, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/task_orchestrator/ui/templates/base.html
+++ b/src/task_orchestrator/ui/templates/base.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Task Orchestrator — Kanban</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.6/Sortable.min.js"></script>
+    <style>
+        .sortable-ghost { opacity: 0.4; }
+        .column-drop-active { background-color: rgba(59, 130, 246, 0.05); }
+    </style>
+</head>
+<body class="bg-gray-900 text-gray-100 min-h-screen">
+    {% block content %}{% endblock %}
+</body>
+</html>

--- a/src/task_orchestrator/ui/templates/board.html
+++ b/src/task_orchestrator/ui/templates/board.html
@@ -1,0 +1,79 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="p-4">
+    <!-- Workspace tabs -->
+    <div class="flex items-center gap-2 mb-4">
+        <h1 class="text-xl font-bold mr-4">📋 Kanban</h1>
+        <a href="/board/_all"
+           class="px-3 py-1 rounded text-sm {% if workspace == '_all' %}bg-blue-600{% else %}bg-gray-700 hover:bg-gray-600{% endif %}">
+            All
+        </a>
+        {% for ws_name in workspaces %}
+        <a href="/board/{{ ws_name }}"
+           class="px-3 py-1 rounded text-sm {% if workspace == ws_name %}bg-blue-600{% else %}bg-gray-700 hover:bg-gray-600{% endif %}">
+            {{ ws_name }}
+        </a>
+        {% endfor %}
+    </div>
+
+    <!-- Board columns -->
+    <div class="grid grid-cols-4 gap-4" id="board">
+        {% for status in statuses %}
+        <div class="bg-gray-800 rounded-lg p-3 min-h-[70vh]">
+            <h2 class="text-sm font-semibold uppercase text-gray-400 mb-3 flex justify-between">
+                {{ status }}
+                <span class="bg-gray-700 px-2 rounded-full text-xs">{{ columns[status]|length }}</span>
+            </h2>
+            <div class="kanban-column space-y-2" data-status="{{ status }}" id="col-{{ status }}">
+                {% for item in columns[status] %}
+                {% include "partials/card.html" %}
+                {% endfor %}
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+</div>
+
+<script>
+document.querySelectorAll('.kanban-column').forEach(col => {
+    new Sortable(col, {
+        group: 'kanban',
+        animation: 150,
+        ghostClass: 'sortable-ghost',
+        onEnd: function(evt) {
+            const itemId = evt.item.dataset.id;
+            const newStatus = evt.to.dataset.status;
+            const workspace = '{{ workspace }}';
+
+            fetch('/board/move', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+                body: `item_id=${itemId}&new_status=${newStatus}&workspace=${workspace}`
+            }).then(r => r.text()).then(html => {
+                // Refresh all columns
+                const tmp = document.createElement('div');
+                tmp.innerHTML = html;
+                const newCols = tmp.querySelectorAll('[data-status]');
+                newCols.forEach(newCol => {
+                    const status = newCol.dataset.status;
+                    const existing = document.getElementById('col-' + status);
+                    if (existing) {
+                        existing.parentElement.querySelector('span').textContent = newCol.querySelectorAll('.card').length;
+                        existing.innerHTML = newCol.innerHTML;
+                    }
+                });
+                // Re-init sortable
+                document.querySelectorAll('.kanban-column').forEach(c => {
+                    new Sortable(c, {
+                        group: 'kanban',
+                        animation: 150,
+                        ghostClass: 'sortable-ghost',
+                        onEnd: arguments.callee
+                    });
+                });
+            });
+        }
+    });
+});
+</script>
+{% endblock %}

--- a/src/task_orchestrator/ui/templates/partials/card.html
+++ b/src/task_orchestrator/ui/templates/partials/card.html
@@ -1,0 +1,16 @@
+<div class="card bg-gray-750 border border-gray-700 rounded p-2 cursor-move hover:border-gray-500 transition-colors"
+     data-id="{{ item.id }}" draggable="true"
+     style="background-color: rgb(40, 44, 52);">
+    <div class="flex justify-between items-start">
+        <span class="font-medium text-sm truncate max-w-[80%]">{{ item.title }}</span>
+        <span class="text-sm" title="{{ item.priority }}">{{ item.priority_emoji }}</span>
+    </div>
+    {% if item.tags %}
+    <div class="flex flex-wrap gap-1 mt-1">
+        {% for tag in item.tags.split(',') if tag.strip() %}
+        <span class="text-xs bg-gray-700 text-gray-300 px-1.5 rounded">{{ tag.strip() }}</span>
+        {% endfor %}
+    </div>
+    {% endif %}
+    <div class="text-xs text-gray-400 mt-1">{{ item.age }}d ago</div>
+</div>

--- a/src/task_orchestrator/ui/templates/partials/column.html
+++ b/src/task_orchestrator/ui/templates/partials/column.html
@@ -1,0 +1,8 @@
+<div class="kanban-column space-y-2" data-status="{{ status }}" id="col-{{ status }}">
+    {% if error %}
+    <div class="text-xs text-red-400 bg-red-900/30 rounded p-1 mb-1">{{ error }}</div>
+    {% endif %}
+    {% for item in items %}
+    {% include "partials/card.html" %}
+    {% endfor %}
+</div>


### PR DESCRIPTION
Local web interface with kanban board per workspace. FastAPI + HTMX + Tailwind + SortableJS. Drag-and-drop status transitions.

## Changes
- New `src/task_orchestrator/ui/` package with FastAPI app
- Jinja2 templates: board layout, card partials, column partials
- SortableJS drag-and-drop between columns triggers `advance_item`
- Workspace selector tabs
- CLI: `task-orchestrator-ui --port 8080 --db path`
- New `[ui]` optional dependency group in pyproject.toml

## Usage
```bash
pip install -e ".[ui]"
task-orchestrator-ui --port 8080
```