### PR TITLE
feat: add auto-archive for done items

### DIFF
--- a/src/task_orchestrator/engine.py
+++ b/src/task_orchestrator/engine.py
@@ -22,7 +22,7 @@ from croniter import croniter, CroniterBadCronError
 
 from .workspace import get_workspace_tags, get_workspace_config
 
-VALID_STATUSES = {"queue", "work", "review", "done", "blocked", "cancelled"}
+VALID_STATUSES = {"queue", "work", "review", "done", "blocked", "cancelled", "archived"}
 
 
 class ToolError(Exception):
@@ -70,7 +70,7 @@ def resolve_short_id(prefix: str) -> str:
         conn.close()
 
 
-TERMINAL = {"done", "cancelled"}
+TERMINAL = {"done", "cancelled", "archived"}
 PRIORITIES = {"critical", "high", "medium", "low"}
 PRIORITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
 
@@ -85,6 +85,7 @@ TRANSITIONS = {
         "blocked": "cancelled",
     },
     "reopen": {"done": "queue", "cancelled": "queue"},
+    "archive": {"done": "archived"},
 }
 
 
@@ -737,6 +738,7 @@ def _get_unsatisfied_blockers(conn, item_id: str) -> list[dict]:
         "review": 2,
         "done": 3,
         "cancelled": 3,
+        "archived": 3,
         "blocked": 0,
     }
     rows = conn.execute(
@@ -869,6 +871,7 @@ def get_context(
     item_id: str | None = None,
     include_ancestors: bool = False,
     workspace: str | None = None,
+    include_archived: bool = False,
 ) -> dict:
     conn = get_connection()
     try:
@@ -913,12 +916,21 @@ def get_context(
             return result
         # Global context
         ws_clause, ws_params = _workspace_tag_filter(workspace)
-        ws_where = f"WHERE {ws_clause}" if ws_clause else ""
         ws_and = f"AND {ws_clause}" if ws_clause else ""
+
+        # Combine workspace + archived filters for WHERE clause
+        if ws_clause and not include_archived:
+            combined_where = f"WHERE {ws_clause} AND status != 'archived'"
+        elif ws_clause:
+            combined_where = f"WHERE {ws_clause}"
+        elif not include_archived:
+            combined_where = "WHERE status != 'archived'"
+        else:
+            combined_where = ""
 
         counts = {}
         for row in conn.execute(
-            f"SELECT status, COUNT(*) as cnt FROM work_items {ws_where} GROUP BY status",
+            f"SELECT status, COUNT(*) as cnt FROM work_items {combined_where} GROUP BY status",
             ws_params,
         ).fetchall():
             counts[row["status"]] = row["cnt"]
@@ -1351,9 +1363,9 @@ def get_metrics(days: int = 30, workspace: str | None = None) -> dict:
         cutoff = (now_dt - timedelta(days=days)).isoformat()
         stale_cutoff = (now_dt - timedelta(days=7)).isoformat()
 
-        # Throughput per week (done items in period, grouped by ISO week)
+        # Throughput per week (done+archived items in period, grouped by ISO week)
         rows = conn.execute(
-            f"SELECT updated_at FROM work_items WHERE status='done' AND updated_at >= ? {ws_and}",
+            f"SELECT updated_at FROM work_items WHERE status IN ('done','archived') AND updated_at >= ? {ws_and}",
             [cutoff] + ws_params,
         ).fetchall()
         week_counts: dict[str, int] = {}
@@ -1364,9 +1376,9 @@ def get_metrics(days: int = 30, workspace: str | None = None) -> dict:
             week_counts[key] = week_counts.get(key, 0) + 1
         throughput = [{"week": w, "count": c} for w, c in sorted(week_counts.items())]
 
-        # Lead time avg (done items in period)
+        # Lead time avg (done+archived items in period)
         lt_rows = conn.execute(
-            f"SELECT created_at, updated_at FROM work_items WHERE status='done' AND updated_at >= ? {ws_and}",
+            f"SELECT created_at, updated_at FROM work_items WHERE status IN ('done','archived') AND updated_at >= ? {ws_and}",
             [cutoff] + ws_params,
         ).fetchall()
         if lt_rows:
@@ -1388,11 +1400,11 @@ def get_metrics(days: int = 30, workspace: str | None = None) -> dict:
 
         # Stale ratio
         non_terminal = conn.execute(
-            f"SELECT COUNT(*) as cnt FROM work_items WHERE status NOT IN ('done','cancelled') {ws_and}",
+            f"SELECT COUNT(*) as cnt FROM work_items WHERE status NOT IN ('done','cancelled','archived') {ws_and}",
             ws_params,
         ).fetchone()["cnt"]
         stale = conn.execute(
-            f"SELECT COUNT(*) as cnt FROM work_items WHERE status NOT IN ('done','cancelled') AND updated_at < ? {ws_and}",
+            f"SELECT COUNT(*) as cnt FROM work_items WHERE status NOT IN ('done','cancelled','archived') AND updated_at < ? {ws_and}",
             [stale_cutoff] + ws_params,
         ).fetchone()["cnt"]
         stale_ratio = (stale / non_terminal * 100) if non_terminal else 0.0
@@ -1400,7 +1412,7 @@ def get_metrics(days: int = 30, workspace: str | None = None) -> dict:
         # By priority (done in period)
         by_priority = {"critical": 0, "high": 0, "medium": 0, "low": 0}
         for r in conn.execute(
-            f"SELECT priority, COUNT(*) as cnt FROM work_items WHERE status='done' AND updated_at >= ? {ws_and} GROUP BY priority",
+            f"SELECT priority, COUNT(*) as cnt FROM work_items WHERE status IN ('done','archived') AND updated_at >= ? {ws_and} GROUP BY priority",
             [cutoff] + ws_params,
         ).fetchall():
             if r["priority"] in by_priority:
@@ -1409,7 +1421,7 @@ def get_metrics(days: int = 30, workspace: str | None = None) -> dict:
         # By tag (top 10 tags across non-terminal items)
         tag_counts: dict[str, int] = {}
         for r in conn.execute(
-            f"SELECT tags FROM work_items WHERE status NOT IN ('done','cancelled') AND tags != '' {ws_and}",
+            f"SELECT tags FROM work_items WHERE status NOT IN ('done','cancelled','archived') AND tags != '' {ws_and}",
             ws_params,
         ).fetchall():
             for tag in r["tags"].split(","):
@@ -1434,6 +1446,79 @@ def get_metrics(days: int = 30, workspace: str | None = None) -> dict:
             "total_items": total,
             "period_days": days,
         }
+    finally:
+        conn.close()
+
+
+# --- Archive ---
+
+
+def archive_items(workspace: str | None = None, days: int = 30) -> dict:
+    """Move items in 'done' status older than `days` to 'archived'."""
+    conn = get_connection()
+    try:
+        now_dt = datetime.now(timezone.utc)
+        cutoff = (now_dt - timedelta(days=days)).isoformat()
+        ws_clause, ws_params = _workspace_tag_filter(workspace)
+        ws_and = f" AND {ws_clause}" if ws_clause else ""
+
+        rows = conn.execute(
+            f"SELECT id FROM work_items WHERE status='done' AND updated_at < ? {ws_and}",
+            [cutoff] + ws_params,
+        ).fetchall()
+
+        now = _now()
+        ids = [r["id"] for r in rows]
+        for item_id in ids:
+            conn.execute(
+                "UPDATE work_items SET status='archived', role_changed_at=?, updated_at=? WHERE id=?",
+                (now, now, item_id),
+            )
+        conn.commit()
+        return {"archived_count": len(ids), "archived_ids": ids}
+    finally:
+        conn.close()
+
+
+def archive_stats(workspace: str | None = None, days: int = 30) -> dict:
+    """Return count of archived items and items eligible for archiving."""
+    conn = get_connection()
+    try:
+        ws_clause, ws_params = _workspace_tag_filter(workspace)
+        ws_and = f" AND {ws_clause}" if ws_clause else ""
+
+        archived_count = conn.execute(
+            f"SELECT COUNT(*) as cnt FROM work_items WHERE status='archived' {ws_and}",
+            ws_params,
+        ).fetchone()["cnt"]
+
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+        eligible_count = conn.execute(
+            f"SELECT COUNT(*) as cnt FROM work_items WHERE status='done' AND updated_at < ? {ws_and}",
+            [cutoff] + ws_params,
+        ).fetchone()["cnt"]
+
+        return {
+            "archived_count": archived_count,
+            "eligible_count": eligible_count,
+            "archive_after_days": days,
+        }
+    finally:
+        conn.close()
+
+
+def archive_list(workspace: str | None = None) -> list[dict]:
+    """Return all archived items, optionally filtered by workspace."""
+    conn = get_connection()
+    try:
+        ws_clause, ws_params = _workspace_tag_filter(workspace)
+        ws_and = f" AND {ws_clause}" if ws_clause else ""
+
+        rows = conn.execute(
+            f"SELECT * FROM work_items WHERE status='archived' {ws_and} ORDER BY updated_at DESC",
+            ws_params,
+        ).fetchall()
+        return [_row_to_dict(r) for r in rows]
     finally:
         conn.close()
 

--- a/src/task_orchestrator/server.py
+++ b/src/task_orchestrator/server.py
@@ -225,7 +225,10 @@ def get_next_item(workspace: str = "") -> str:
 
 @mcp.tool()
 def get_context(
-    item_id: str = "", include_ancestors: bool = False, workspace: str = ""
+    item_id: str = "",
+    include_ancestors: bool = False,
+    workspace: str = "",
+    include_archived: bool = False,
 ) -> str:
     """Get context snapshot for session resume or item inspection.
 
@@ -233,6 +236,7 @@ def get_context(
     With item_id: item detail — children, notes, blockers, can_advance flag.
     Use include_ancestors=true to get the full parent chain.
     Use workspace to filter by workspace tags (e.g. workspace="dtp").
+    Use include_archived=true to include archived items in counts (excluded by default).
     Call this at session start to understand current work state.
     """
     try:
@@ -241,6 +245,7 @@ def get_context(
                 _resolve(item_id) or None,
                 include_ancestors=include_ancestors,
                 workspace=workspace or None,
+                include_archived=include_archived,
             )
         )
     except Exception as e:
@@ -511,6 +516,32 @@ def get_metrics(days: int = 30, workspace: str = "") -> str:
     """
     try:
         return _json(engine.get_metrics(days=days, workspace=workspace or None))
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def manage_archive(
+    operation: str, workspace: str = "", archive_after_days: int = 30
+) -> str:
+    """Auto-archive completed items. Moves 'done' items older than archive_after_days to 'archived'.
+
+    Operations:
+    - run: archive eligible items (done status, older than archive_after_days)
+    - stats: return count of archived items and eligible items
+    - list: return all archived items (with optional workspace filter)
+    """
+    try:
+        ws = workspace or None
+        if operation == "run":
+            return _json(engine.archive_items(workspace=ws, days=archive_after_days))
+        elif operation == "stats":
+            return _json(engine.archive_stats(workspace=ws, days=archive_after_days))
+        elif operation == "list":
+            return _json(engine.archive_list(workspace=ws))
+        return _json(
+            {"error": f"Invalid operation: {operation}. Use: run, stats, list"}
+        )
     except Exception as e:
         return _err(e)
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,0 +1,180 @@
+"""Tests for auto-archive feature (issue #31)."""
+
+from datetime import datetime, timezone, timedelta
+
+from task_orchestrator import db, engine
+
+
+class TestArchiveTransition:
+    """Test the archive trigger in the state machine."""
+
+    def test_archive_from_done(self, tmp_db):
+        item = engine.create_item(title="Test item")
+        engine.advance_item(item["id"], "complete")
+        result = engine.advance_item(item["id"], "archive")
+        assert result["status"] == "archived"
+
+    def test_archive_from_non_done_fails(self, tmp_db):
+        item = engine.create_item(title="Test item")
+        try:
+            engine.advance_item(item["id"], "archive")
+            assert False, "Should have raised"
+        except engine.ToolError as e:
+            assert e.code == "CONFLICT"
+
+    def test_archived_is_terminal(self, tmp_db):
+        item = engine.create_item(title="Test item")
+        engine.advance_item(item["id"], "complete")
+        engine.advance_item(item["id"], "archive")
+        # Cannot start/complete/block from archived
+        try:
+            engine.advance_item(item["id"], "start")
+            assert False, "Should have raised"
+        except engine.ToolError as e:
+            assert e.code == "CONFLICT"
+
+    def test_reopen_from_archived_not_allowed(self, tmp_db):
+        """Archived items cannot be reopened (not in reopen transitions)."""
+        item = engine.create_item(title="Test item")
+        engine.advance_item(item["id"], "complete")
+        engine.advance_item(item["id"], "archive")
+        try:
+            engine.advance_item(item["id"], "reopen")
+            assert False, "Should have raised"
+        except engine.ToolError as e:
+            assert e.code == "CONFLICT"
+
+
+class TestArchiveItems:
+    """Test the archive_items bulk operation."""
+
+    def test_archive_old_done_items(self, tmp_db):
+        conn = db.get_connection()
+        # Create item and mark done with old updated_at
+        item = engine.create_item(title="Old done item")
+        engine.advance_item(item["id"], "complete")
+        old_date = (datetime.now(timezone.utc) - timedelta(days=45)).isoformat()
+        conn.execute(
+            "UPDATE work_items SET updated_at=? WHERE id=?", (old_date, item["id"])
+        )
+        conn.commit()
+        conn.close()
+
+        result = engine.archive_items(days=30)
+        assert result["archived_count"] == 1
+        assert item["id"] in result["archived_ids"]
+
+        # Verify status changed
+        updated = engine.get_item(item["id"])
+        assert updated["status"] == "archived"
+
+    def test_archive_skips_recent_done(self, tmp_db):
+        item = engine.create_item(title="Recent done item")
+        engine.advance_item(item["id"], "complete")
+
+        result = engine.archive_items(days=30)
+        assert result["archived_count"] == 0
+
+    def test_archive_skips_non_done(self, tmp_db):
+        conn = db.get_connection()
+        item = engine.create_item(title="Work item")
+        engine.advance_item(item["id"], "start")
+        old_date = (datetime.now(timezone.utc) - timedelta(days=45)).isoformat()
+        conn.execute(
+            "UPDATE work_items SET updated_at=? WHERE id=?", (old_date, item["id"])
+        )
+        conn.commit()
+        conn.close()
+
+        result = engine.archive_items(days=30)
+        assert result["archived_count"] == 0
+
+
+class TestArchiveStats:
+    """Test archive_stats."""
+
+    def test_stats_counts(self, tmp_db):
+        conn = db.get_connection()
+        # Create 1 old done item
+        item1 = engine.create_item(title="Old")
+        engine.advance_item(item1["id"], "complete")
+        old_date = (datetime.now(timezone.utc) - timedelta(days=45)).isoformat()
+        conn.execute(
+            "UPDATE work_items SET updated_at=? WHERE id=?", (old_date, item1["id"])
+        )
+        conn.commit()
+        conn.close()
+
+        # Create recent done item
+        item2 = engine.create_item(title="Recent")
+        engine.advance_item(item2["id"], "complete")
+
+        # Archive one manually
+        item3 = engine.create_item(title="Already archived")
+        engine.advance_item(item3["id"], "complete")
+        engine.advance_item(item3["id"], "archive")
+
+        stats = engine.archive_stats(days=30)
+        assert stats["archived_count"] == 1
+        assert stats["eligible_count"] == 1
+        assert stats["archive_after_days"] == 30
+
+
+class TestArchiveList:
+    """Test archive_list."""
+
+    def test_list_archived(self, tmp_db):
+        item = engine.create_item(title="To archive")
+        engine.advance_item(item["id"], "complete")
+        engine.advance_item(item["id"], "archive")
+
+        items = engine.archive_list()
+        assert len(items) == 1
+        assert items[0]["id"] == item["id"]
+
+
+class TestGetContextExcludesArchived:
+    """Test that get_context excludes archived items by default."""
+
+    def test_context_excludes_archived_from_counts(self, tmp_db):
+        item = engine.create_item(title="Archived item")
+        engine.advance_item(item["id"], "complete")
+        engine.advance_item(item["id"], "archive")
+
+        ctx = engine.get_context()
+        assert "archived" not in ctx["counts"]
+
+    def test_context_includes_archived_when_requested(self, tmp_db):
+        item = engine.create_item(title="Archived item")
+        engine.advance_item(item["id"], "complete")
+        engine.advance_item(item["id"], "archive")
+
+        ctx = engine.get_context(include_archived=True)
+        assert "archived" in ctx["counts"]
+        assert ctx["counts"]["archived"] == 1
+
+
+class TestGetNextItemExcludesArchived:
+    """Archived items should never appear in get_next_item."""
+
+    def test_next_item_skips_archived(self, tmp_db):
+        item = engine.create_item(title="Archived")
+        engine.advance_item(item["id"], "complete")
+        engine.advance_item(item["id"], "archive")
+
+        result = engine.get_next_item()
+        assert result is None
+
+
+class TestMetricsIncludesArchived:
+    """Archived items should count in throughput metrics."""
+
+    def test_metrics_counts_archived_in_throughput(self, tmp_db):
+        item = engine.create_item(title="Archived item")
+        engine.advance_item(item["id"], "complete")
+        engine.advance_item(item["id"], "archive")
+
+        metrics = engine.get_metrics(days=30)
+        # archived item should be counted in throughput
+        total_throughput = sum(w["count"] for w in metrics["throughput_per_week"])
+        assert total_throughput >= 1


### PR DESCRIPTION
## Summary
Implements auto-archive feature (closes #31).

## Changes
- New 'archived' status in state machine (done → archived via 'archive' trigger)
- New `manage_archive` MCP tool with operations: run, stats, list
- `get_context` excludes archived items by default (new `include_archived` param)
- `get_metrics` includes archived items in throughput/lead-time counts
- 'archived' added to TERMINAL set — cannot start/complete/block from archived

## Files changed
- `src/task_orchestrator/engine.py` — state machine + archive functions
- `src/task_orchestrator/server.py` — manage_archive tool registration
- `tests/test_archive.py` — 13 new tests

## Testing
All 108 tests pass.